### PR TITLE
Fix pre-/postcondition checks for contextually convertible types

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ int * use( gsl::not_null<int *> p )
 
 struct Widget
 {
-    Widget() : owned_ptr( new int(42) ) {}
-    ~Widget() { delete owned_ptr; }
+    Widget() : owned_ptr_( new int(42) ) {}
+    ~Widget() { delete owned_ptr_; }
 
-    void work() { non_owned_ptr_ = use( owned_ptr ); }
+    void work() { non_owned_ptr_ = use( owned_ptr_ ); }
     
-    owner<int *> owned_ptr_; // if alias template support
+    gsl::owner<int *> owned_ptr_; // if alias template support
     int * non_owned_ptr_;
 };
 
@@ -340,13 +340,13 @@ target_link_libraries( my-statistics-lib PUBLIC gsl::gsl-lite-v1 )
 
 namespace my_statistics_lib {
 
-namespace gsl = ::gsl_lite; // convenience alias
+    namespace gsl = ::gsl_lite; // convenience alias
 
-double mean( gsl::span< double const > elements )
-{
-    gsl_Expects( !elements.empty() ); // instead of Expects()
-    ...
-}
+    double mean( gsl::span<double const> elements )
+    {
+        gsl_Expects( !elements.empty() ); // instead of Expects()
+        ...
+    }
 
 } // namespace my_statistics_lib
 ```

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -1148,7 +1148,7 @@ typedef gsl_CONFIG_INDEX_TYPE index;
 //
 
 #if gsl_HAVE( TYPE_TRAITS )
-# define gsl_ELIDE_CONTRACT_( x )  static_assert(::std::is_convertible<decltype(( x )), bool>::value, "argument of contract check must be convertible to bool")
+# define gsl_ELIDE_CONTRACT_( x )  static_assert(::std::is_constructible<bool, decltype( x )>::value, "argument of contract check must be convertible to bool")
 #else
 # define gsl_ELIDE_CONTRACT_( x )
 #endif

--- a/test/assert.t.cpp
+++ b/test/assert.t.cpp
@@ -104,6 +104,9 @@ void testConvertibleToBool()
     // `gsl_Expects()` should be compatible with explicit conversions to bool.
     gsl_Expects( ConvertibleToBool() );
 
+    // `gsl_CONFIG_CONTRACT_CHECKING_OFF` should be compatible with explicit conversions to bool.
+    gsl_ELIDE_CONTRACT_( ConvertibleToBool() );
+
     if ( ConvertibleToBool() ) { } // to get rid of weird NVCC warning about never-referenced conversion operator
 }
 

--- a/test/assert.t.cpp
+++ b/test/assert.t.cpp
@@ -35,7 +35,7 @@ struct ConvertibleToBool
 };
 
 
-}
+} // anonymous namespace
 
 CASE( "gsl_Expects(): Allows a true expression" )
 {
@@ -87,7 +87,7 @@ CASE( "gsl_EnsuresAudit(): Terminates on a false expression in AUDIT mode" )
 
 int testAssume( int i, std::vector<int> const& v )
 {
-    // The arguments to `__assume(x)` (MSVC) and `__builtin_assume(x)` (Clang) are never evaluated, so they cannot incur side-effects. We would like to implement
+    // The arguments to `__assume( x )` (MSVC) and `__builtin_assume( x )` (Clang) are never evaluated, so they cannot incur side-effects. We would like to implement
     // `gsl_ASSUME()` in terms of these. However, Clang always emits a diagnostic if a potential side-effect is discarded, and every call to a function not annotated
     // `__attribute__ ((pure))` or `__attribute__ ((const))` is considered a potential side-effect (e.g. the call to `v.size()` below). In many cases Clang is capable
     // of inlining the expression and find it free of side-effects, cf. https://gcc.godbolt.org/z/ZcKfbp, but the warning is produced anyway.


### PR DESCRIPTION
Fixes a spurious static assertion for pre-/postcondition check arguments explicitly convertible to `bool` if `gsl_CONFIG_CONTRACT_CHECKING_OFF` is defined.

This PR also applies some minor formatting changes.