### PR TITLE
Allow C++11 on GCC 4.7

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -86,7 +86,7 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang" )
     if( CMAKE_CXX_COMPILER_ID MATCHES "GNU" )
         message( STATUS "Matched: GNU")
 
-        if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8.0 )
+        if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.7.0 )
             set( HAS_CPP11_FLAG TRUE )
         endif()
         if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.2 )


### PR DESCRIPTION
Building GSL-Lite with GCC 4.7's almost, but not quite full C++11 support mode is the sole reason for the existence of the travis GCC 4.7 build and `gsl_HAVE( FUNCTION_REF_QUALIFIER )`. I do not know how I missed it when I added GCC 4.7. :D