### PR TITLE
Span default constructor is now constexpr from C++11.

### DIFF
--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -2609,7 +2609,7 @@ public:
 
     // 26.7.3.2 Constructors, copy, and assignment [span.cons]
 
-    gsl_api gsl_constexpr14 span() gsl_noexcept
+    gsl_api gsl_constexpr span() gsl_noexcept
         : first_( gsl_nullptr )
         , last_ ( gsl_nullptr )
     {

--- a/test/span.t.cpp
+++ b/test/span.t.cpp
@@ -578,6 +578,16 @@ CASE( "span<>: Allows to construct from a non-empty gsl::unique_ptr (array, C++1
 #endif
 }
 
+CASE( "span<>: Allows to default construct in a constexpr context")
+{
+#if gsl_HAVE_CONSTEXPR_11
+    constexpr auto spn = gsl::span<int>{ };
+    EXPECT( spn.size() == index_type( 0 ) );
+#else
+    EXPECT( !!"construction in a constexpr context is not available (C++11)");
+#endif    
+}
+
 CASE( "span<>: Allows to copy-construct from another span of the same type" )
 {
     int arr[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, };


### PR DESCRIPTION
Fixes #270, in which using this construct failed to compile in C++14 mode for gcc 5.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gsl-lite/gsl-lite/271)
<!-- Reviewable:end -->
