### PR TITLE
add not_null_ic to gsl_lite namespace

### DIFF
--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -4441,6 +4441,7 @@ using ::gsl::narrow_failfast;
 using ::gsl::at;
 
 using ::gsl::not_null;
+using ::gsl::not_null_ic;
 using ::gsl::make_not_null;
 
 using ::gsl::byte;


### PR DESCRIPTION
I found not_null_ic is not in the gsl_lite namespace.
Is this a mistake or deliberate ?
