### PR TITLE
Make `gsl_CONFIG_CONTRACT_VIOLATION_ASSERTS` the version-1 default

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Macro                                                                           
 [`gsl_CONFIG_NOT_NULL_EXPLICIT_CTOR`](#gsl_config_not_null_explicit_ctor0)           | 0                                                        | 1                 | cf. reasoning in [M-GSL/#395](https://github.com/Microsoft/GSL/issues/395) (note that `not_null<>` in M-GSL has an implicit constructor, cf. [M-GSL/#699](https://github.com/Microsoft/GSL/issues/699)) |
 [`gsl_CONFIG_TRANSPARENT_NOT_NULL`](#gsl_config_transparent_not_null0)               | 0                                                        | 1                 | enables conformant behavior for `not_null<>::get()` |
 [`gsl_CONFIG_NARROW_THROWS_ON_TRUNCATION`](#gsl_config_narrow_throws_on_truncation0) | 0                                                        | 1                 | enables conformant behavior for `narrow<>()` (cf. [#52](https://github.com/gsl-lite/gsl-lite/issues/52)) |
+[`gsl_CONFIG_CONTRACT_VIOLATION_*`](#contract-checking-configuration-macros)         | `gsl_CONFIG_CONTRACT_VIOLATION_TERMINATES`               | `gsl_CONFIG_CONTRACT_VIOLATION_ASSERTS` | |
 
 Note that the v1 defaults are not yet stable; future 0.\* releases may introduce more configuration switches with different version-specific defaults.
 

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -381,11 +381,11 @@
 #endif
 #if 0 == defined( gsl_CONFIG_CONTRACT_VIOLATION_THROWS ) + defined( gsl_CONFIG_CONTRACT_VIOLATION_TERMINATES ) + defined( gsl_CONFIG_CONTRACT_VIOLATION_ASSERTS ) + defined( gsl_CONFIG_CONTRACT_VIOLATION_TRAPS ) + defined( gsl_CONFIG_CONTRACT_VIOLATION_CALLS_HANDLER )
 // select default
-//# if gsl_CONFIG_DEFAULTS_VERSION >= 1
-//#  define gsl_CONFIG_CONTRACT_VIOLATION_ASSERTS  // This is still controversial because it's non-conforming.
-//# else
+# if gsl_CONFIG_DEFAULTS_VERSION >= 1
+#  define gsl_CONFIG_CONTRACT_VIOLATION_ASSERTS
+# else
 #  define gsl_CONFIG_CONTRACT_VIOLATION_TERMINATES
-//# endif
+# endif
 #endif
 #if 0 == defined( gsl_CONFIG_UNENFORCED_CONTRACTS_ASSUME ) + defined( gsl_CONFIG_UNENFORCED_CONTRACTS_ELIDE )
 // select default


### PR DESCRIPTION
The contract violation handling configuration option `gsl_CONFIG_CONTRACT_VIOLATION_ASSERTS` implements `gsl_Expects()`/`gsl_Ensures()`/`gsl_Assert()` (and the `Audit` variants if audit mode is enabled) in terms of the [`assert()`](https://en.cppreference.com/w/cpp/error/assert) macro from the standard library. This has the benefits that *all* assertions can be globally suppressed with a single macro (i.e. `NDEBUG`), and that `assert()` prints an informative error message which contains the contract check expression.

Because it is so convenient, I'd like to make `gsl_CONFIG_CONTRACT_VIOLATION_ASSERTS` the default in the next major version. However, as pointed out in #294, this would render our default behavior slightly non-compliant because the Core Guidelines specify that contract violation leads to termination unless configured otherwise, cf. https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#gslassert-assertions.