### PR TITLE
Add `std20::endian`, fix `byte` tests for big-endian architectures

### DIFF
--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -942,11 +942,7 @@
     //
     // Defines bitmask operators `|`, `&`, `^`, `~`, `|=`, `&=`, and `^=` for the given enum type.
     //
-    //     enum class Vegetables {
-    //         tomato   = 0b001,
-    //         onion    = 0b010,
-    //         eggplant = 0b100
-    //     };
+    //     enum class Vegetables { tomato = 0b001, onion = 0b010, eggplant = 0b100 };
     //     gsl_DEFINE_ENUM_BITMASK_OPERATORS( Vegetables )
     //
 #define gsl_DEFINE_ENUM_BITMASK_OPERATORS( ENUM ) gsl_DEFINE_ENUM_BITMASK_OPERATORS_( ENUM )
@@ -954,11 +950,7 @@
     //
     // Defines relational operators `<`, `>`, `<=`, `>=` for the given enum type.
     //
-    //     enum class OperatorPrecedence {
-    //         additive = 0,
-    //         multiplicative = 1,
-    //         power = 2
-    //     };
+    //     enum class OperatorPrecedence { additive = 0, multiplicative = 1, power = 2 };
     //     gsl_DEFINE_ENUM_RELATIONAL_OPERATORS( OperatorPrecedence )
     //
 #define gsl_DEFINE_ENUM_RELATIONAL_OPERATORS( ENUM ) gsl_DEFINE_ENUM_RELATIONAL_OPERATORS_( ENUM )
@@ -1037,7 +1029,7 @@
 # include <iterator> // for reverse_iterator<>
 #endif
 
-#if !gsl_HAVE( CONSTRAINED_SPAN_CONTAINER_CTOR ) || !gsl_HAVE( AUTO )
+#if ! gsl_HAVE( CONSTRAINED_SPAN_CONTAINER_CTOR ) || ! gsl_HAVE( AUTO )
 # include <vector>
 #endif
 
@@ -1051,6 +1043,10 @@
 
 #if defined( gsl_CONFIG_CONTRACT_VIOLATION_TRAPS ) && gsl_COMPILER_MSVC_VERSION >= 110 // __fastfail() supported by VS 2012 and later
 # include <intrin.h>
+#endif
+
+#if gsl_HAVE( ENUM_CLASS ) && gsl_COMPILER_ARMCC_VERSION
+# include <endian.h>
 #endif
 
 #if gsl_HAVE( TYPE_TRAITS )
@@ -1389,6 +1385,28 @@ struct identity
         return std::forward<T>( arg );
     }
 };
+
+# if gsl_HAVE( ENUM_CLASS )
+enum class endian
+{
+#  if defined( _WIN32 )
+    little = 0,
+    big    = 1,
+    native = little
+#  elif gsl_COMPILER_GNUC_VERSION || gsl_COMPILER_CLANG_VERSION || gsl_COMPILER_APPLECLANG_VERSION
+    little = __ORDER_LITTLE_ENDIAN__,
+    big    = __ORDER_BIG_ENDIAN__,
+    native = __BYTE_ORDER__
+#  elif gsl_COMPILER_ARMCC_VERSION
+    // from <endian.h> header file
+    little = __LITTLE_ENDIAN,
+    big    = __BIG_ENDIAN,
+    native = __BYTE_ORDER
+#  else
+// Do not define any endianness constants for unknown compilers.
+#  endif
+};
+# endif // gsl_HAVE( ENUM_CLASS )
 
 #endif // gsl_CPP11_100
 

--- a/test/issue.t.cpp
+++ b/test/issue.t.cpp
@@ -57,6 +57,11 @@ CASE( "span<>: constrained container constructor suffers hard failure for argume
 #endif
 }
 
+#if gsl_COMPILER_MSVC_VERSION
+# pragma warning( push )
+# pragma warning( disable : 4127 ) // conditional expression is constant
+#endif
+
 CASE( "byte: aliasing rules lead to undefined behaviour when using enum class [issue #34](GSL issue #313, PR #390)" )
 {
 #if gsl_HAVE( ENUM_CLASS )
@@ -80,6 +85,10 @@ CASE( "byte: aliasing rules lead to undefined behaviour when using enum class [i
     }
 #endif // gsl_HAVE( ENUM_CLASS )
 }
+
+#if gsl_COMPILER_MSVC_VERSION
+# pragma warning( pop )
+#endif
 
 CASE( "string_span<>: must not include terminating '\\0' [issue #53]" )
 {

--- a/test/issue.t.cpp
+++ b/test/issue.t.cpp
@@ -59,6 +59,7 @@ CASE( "span<>: constrained container constructor suffers hard failure for argume
 
 CASE( "byte: aliasing rules lead to undefined behaviour when using enum class [issue #34](GSL issue #313, PR #390)" )
 {
+#if gsl_HAVE( ENUM_CLASS )
     struct F {
         static int f( int & i, gsl::byte & r )
         {
@@ -68,8 +69,16 @@ CASE( "byte: aliasing rules lead to undefined behaviour when using enum class [i
         }
     };
 
-   int i;
-   EXPECT( 14 == F::f( i, reinterpret_cast<gsl::byte&>( i ) ) );
+    int i = 0;
+    if ( std20::endian::native == std20::endian::little )
+    {
+        EXPECT( 14 == F::f( i, reinterpret_cast<gsl::byte*>( &i )[0] ) );
+    }
+    else if ( std20::endian::native == std20::endian::big )
+    {
+        EXPECT( 14 == F::f( i, reinterpret_cast<gsl::byte*>( &i )[sizeof i - 1] ) );
+    }
+#endif // gsl_HAVE( ENUM_CLASS )
 }
 
 CASE( "string_span<>: must not include terminating '\\0' [issue #53]" )

--- a/test/span.t.cpp
+++ b/test/span.t.cpp
@@ -1684,6 +1684,11 @@ CASE( "byte_span() (gsl_FEATURE_BYTE_SPAN=1)" )
     EXPECT( !!"(avoid warning)" );  // suppress: unused parameter 'lest_env' [-Wunused-parameter]
 }
 
+# if gsl_COMPILER_MSVC_VERSION
+#  pragma warning( push )
+#  pragma warning( disable : 4127 ) // conditional expression is constant
+# endif
+
 CASE( "byte_span(): Allows to build a span of gsl::byte from a single object" )
 {
 # if gsl_HAVE( ENUM_CLASS )
@@ -1731,6 +1736,10 @@ CASE( "byte_span(): Allows to build a span of const gsl::byte from a single cons
     }
 # endif // gsl_HAVE( ENUM_CLASS )
 }
+
+# if gsl_COMPILER_MSVC_VERSION
+#  pragma warning( pop )
+# endif
 
 #endif // span_PROVIDE( BYTE_SPAN )
 

--- a/test/span.t.cpp
+++ b/test/span.t.cpp
@@ -1686,22 +1686,50 @@ CASE( "byte_span() (gsl_FEATURE_BYTE_SPAN=1)" )
 
 CASE( "byte_span(): Allows to build a span of gsl::byte from a single object" )
 {
+# if gsl_HAVE( ENUM_CLASS )
     int x = (std::numeric_limits<int>::max)();
 
     span<gsl::byte> spn = byte_span( x );
 
     EXPECT( spn.size() == index_type( sizeof x ) );
-    EXPECT( spn[0]     == to_byte( 0xff ) );
+    if ( sizeof x > 1 )
+    {
+        if ( std20::endian::native == std20::endian::little )
+        {
+            EXPECT( spn[0]            == to_byte( 0xff ) );
+            EXPECT( spn[sizeof x - 1] == to_byte( 0x7f ) );
+        }
+        else if ( std20::endian::native == std20::endian::big )
+        {
+            EXPECT( spn[sizeof x - 1] == to_byte( 0xff ) );
+            EXPECT( spn[0]            == to_byte( 0x7f ) );
+        }
+    }
+# endif // gsl_HAVE( ENUM_CLASS )
 }
 
 CASE( "byte_span(): Allows to build a span of const gsl::byte from a single const object" )
 {
+# if gsl_HAVE( ENUM_CLASS )
     const int x = (std::numeric_limits<int>::max)();
 
     span<const gsl::byte> spn = byte_span( x );
 
     EXPECT( spn.size() == index_type( sizeof x ) );
-    EXPECT( spn[0]     == to_byte( 0xff ) );
+    if ( sizeof x > 1 )
+    {
+        if ( std20::endian::native == std20::endian::little )
+        {
+            EXPECT( spn[0]            == to_byte( 0xff ) );
+            EXPECT( spn[sizeof x - 1] == to_byte( 0x7f ) );
+        }
+        else if ( std20::endian::native == std20::endian::big )
+        {
+            EXPECT( spn[sizeof x - 1] == to_byte( 0xff ) );
+            EXPECT( spn[0]            == to_byte( 0x7f ) );
+        }
+    }
+# endif // gsl_HAVE( ENUM_CLASS )
 }
 
 #endif // span_PROVIDE( BYTE_SPAN )


### PR DESCRIPTION
Fixes #304, hopefully.