### PR TITLE
Basic NVHPC compiler support.

### DIFF
--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -478,7 +478,7 @@
 # define gsl_COMPILER_CLANG_VERSION       0
 #endif
 
-#if defined( __GNUC__ ) && ! defined( __clang__ )
+#if defined( __GNUC__ ) && ! defined( __clang__ ) && ! defined( __NVCOMPILER )
 # define gsl_COMPILER_GNUC_VERSION  gsl_COMPILER_VERSION( __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__ )
 #else
 # define gsl_COMPILER_GNUC_VERSION  0
@@ -488,6 +488,13 @@
 # define gsl_COMPILER_NVCC_VERSION  ( __CUDACC_VER_MAJOR__ * 10 + __CUDACC_VER_MINOR__ )
 #else
 # define gsl_COMPILER_NVCC_VERSION  0
+#endif
+
+// NVHPC 21.2  gsl_COMPILER_NVHPC_VERSION == 2120
+#if defined( __NVCOMPILER )
+# define gsl_COMPILER_NVHPC_VERSION  gsl_COMPILER_VERSION( __NVCOMPILER_MAJOR__, __NVCOMPILER_MINOR__, __NVCOMPILER_PATCHLEVEL__ )
+#else
+# define gsl_COMPILER_NVHPC_VERSION  0
 #endif
 
 #if defined( __ARMCC_VERSION )
@@ -1386,7 +1393,7 @@ struct identity
 # if gsl_HAVE( ENUM_CLASS )
 enum class endian
 {
-#  if defined( _WIN32 )
+#  if defined( _WIN32 ) || gsl_COMPILER_NVHPC_VERSION
     little = 0,
     big    = 1,
     native = little

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -1049,7 +1049,7 @@
 # include <intrin.h>
 #endif
 
-#if gsl_HAVE( ENUM_CLASS ) && gsl_COMPILER_ARMCC_VERSION
+#if gsl_HAVE( ENUM_CLASS ) && ( gsl_COMPILER_ARMCC_VERSION || gsl_COMPILER_NVHPC_VERSION )
 # include <endian.h>
 #endif
 
@@ -1393,7 +1393,7 @@ struct identity
 # if gsl_HAVE( ENUM_CLASS )
 enum class endian
 {
-#  if defined( _WIN32 ) || gsl_COMPILER_NVHPC_VERSION
+#  if defined( _WIN32 )
     little = 0,
     big    = 1,
     native = little
@@ -1401,7 +1401,7 @@ enum class endian
     little = __ORDER_LITTLE_ENDIAN__,
     big    = __ORDER_BIG_ENDIAN__,
     native = __BYTE_ORDER__
-#  elif gsl_COMPILER_ARMCC_VERSION
+#  elif gsl_COMPILER_ARMCC_VERSION || gsl_COMPILER_NVHPC_VERSION
     // from <endian.h> header file
     little = __LITTLE_ENDIAN,
     big    = __BIG_ENDIAN,

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -557,8 +557,8 @@
 #   define gsl_HAVE_EXCEPTIONS  0
 #  endif
 # endif
-#elif gsl_COMPILER_GNUC_VERSION
-# if gsl_BETWEEN(gsl_COMPILER_GNUC_VERSION, 1, 500)
+#elif defined( __GNUC__ )
+# if __GNUC__ < 5
 #  ifdef __EXCEPTIONS
 #   define gsl_HAVE_EXCEPTIONS  1
 #  else
@@ -570,7 +570,7 @@
 #  else
 #   define gsl_HAVE_EXCEPTIONS  0
 #  endif // __cpp_exceptions
-# endif // gsl_BETWEEN(gsl_COMPILER_GNUC_VERSION, 1, 500)
+# endif // __GNUC__ < 5
 #elif gsl_COMPILER_MSVC_VERSION
 # ifdef _CPPUNWIND
 #  define gsl_HAVE_EXCEPTIONS  1
@@ -846,7 +846,7 @@
 # define gsl_NORETURN  [[noreturn]]
 #elif defined(_MSC_VER)
 # define gsl_NORETURN  __declspec(noreturn)
-#elif gsl_COMPILER_GNUC_VERSION || gsl_COMPILER_CLANG_VERSION || gsl_COMPILER_APPLECLANG_VERSION || gsl_COMPILER_ARMCC_VERSION
+#elif defined( __GNUC__ ) || gsl_COMPILER_ARMCC_VERSION
 # define gsl_NORETURN  __attribute__((noreturn))
 #else
 # define gsl_NORETURN
@@ -1049,7 +1049,7 @@
 # include <intrin.h>
 #endif
 
-#if gsl_HAVE( ENUM_CLASS ) && ( gsl_COMPILER_ARMCC_VERSION || gsl_COMPILER_NVHPC_VERSION )
+#if gsl_HAVE( ENUM_CLASS ) && ( gsl_COMPILER_ARMCC_VERSION || gsl_COMPILER_NVHPC_VERSION ) && !defined( _WIN32 )
 # include <endian.h>
 #endif
 
@@ -2151,7 +2151,7 @@ namespace detail {
     template< class T, class U >
     struct is_same_signedness : public std::integral_constant<bool, std::is_signed<T>::value == std::is_signed<U>::value> {};
 
-# if gsl_COMPILER_NVCC_VERSION
+# if gsl_COMPILER_NVCC_VERSION || gsl_COMPILER_NVHPC_VERSION
     // We do this to circumvent NVCC warnings about pointless unsigned comparisons with 0.
     template< class T >
     gsl_constexpr gsl_api bool is_negative( T value, std::true_type /*isSigned*/ ) gsl_noexcept
@@ -2206,7 +2206,7 @@ narrow( U u )
     }
 
 #if gsl_HAVE( TYPE_TRAITS )
-# if gsl_COMPILER_NVCC_VERSION
+# if gsl_COMPILER_NVCC_VERSION || gsl_COMPILER_NVHPC_VERSION
     if ( ! detail::have_same_sign( t, u, detail::is_same_signedness<T, U>() ) )
 # else
     gsl_SUPPRESS_MSVC_WARNING( 4127, "conditional expression is constant" )
@@ -2237,7 +2237,7 @@ narrow_failfast( U u )
     gsl_Expects( static_cast<U>( t ) == u );
 
 #if gsl_HAVE( TYPE_TRAITS )
-# if gsl_COMPILER_NVCC_VERSION
+# if gsl_COMPILER_NVCC_VERSION || gsl_COMPILER_NVHPC_VERSION
     gsl_Expects( ::gsl::detail::have_same_sign( t, u, ::gsl::detail::is_same_signedness<T, U>() ) );
 # else
     gsl_SUPPRESS_MSVC_WARNING( 4127, "conditional expression is constant" )

--- a/test/MakeTestTarget.cmake
+++ b/test/MakeTestTarget.cmake
@@ -81,7 +81,8 @@ if( MSVC )
         endif()
     endif()
 
-elseif( CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang" )
+# Older CMake versions identify NVHPC compilers as PGI.
+elseif( CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang|PGI|NVHPC" )
 
     set( HAS_STD_FLAGS  TRUE )
     set( HAS_CPP98_FLAG TRUE )
@@ -133,8 +134,14 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang" )
         if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0.0 )
             set( HAS_CPP20_FLAG TRUE )
         endif()
+    # Older CMake versions identify NVHPC compilers as PGI.
+    elseif( CMAKE_CXX_COMPILER_ID MATCHES "PGI|NVHPC" )
+        message( STATUS "Matched: NVHPC/PGI ${CMAKE_CXX_COMPILER_VERSION}" )
+        set( HAS_CPP11_FLAG TRUE )
+        set( HAS_CPP14_FLAG TRUE )
+        set( HAS_CPP17_FLAG TRUE )
+        set( HAS_CPP20_FLAG TRUE )
     endif()
-
 elseif( CMAKE_CXX_COMPILER_ID MATCHES "Intel" )
     message( STATUS "Matched: Intel ${CMAKE_CXX_COMPILER_VERSION}" )
 else()

--- a/test/assert.t.cpp
+++ b/test/assert.t.cpp
@@ -36,6 +36,9 @@ enum Color
 #endif
 { red, green, blue };
 
+#if gsl_COMPILER_NVHPC_VERSION
+# pragma diag_suppress 941 // Suppress:  missing return statement at end of non-void function "..."
+#endif
 std::string colorToString( Color color )
 {
     switch (color)
@@ -46,6 +49,10 @@ std::string colorToString( Color color )
     }
     gsl_FailFast();  // this should keep the compiler from issuing a warning about not returning a value
 }
+#if gsl_COMPILER_NVHPC_VERSION
+# pragma diag_default 941
+#endif
+
 
 struct ConvertibleToBool
 {

--- a/test/assert.t.cpp
+++ b/test/assert.t.cpp
@@ -36,7 +36,7 @@ enum Color
 #endif
 { red, green, blue };
 
-#if gsl_COMPILER_NVHPC_VERSION
+#if gsl_COMPILER_NVHPC_VERSION && !gsl_CPP11_OR_GREATER
 # pragma diag_suppress 941 // Suppress:  missing return statement at end of non-void function "..."
 #endif
 std::string colorToString( Color color )
@@ -49,7 +49,7 @@ std::string colorToString( Color color )
     }
     gsl_FailFast();  // this should keep the compiler from issuing a warning about not returning a value
 }
-#if gsl_COMPILER_NVHPC_VERSION
+#if gsl_COMPILER_NVHPC_VERSION && !gsl_CPP11_OR_GREATER
 # pragma diag_default 941
 #endif
 

--- a/test/gsl-lite.t.hpp
+++ b/test/gsl-lite.t.hpp
@@ -69,10 +69,6 @@
 # pragma clang diagnostic ignored "-Wunused-member-function"
 # pragma clang diagnostic warning "-Wunknown-warning-option" // we want to see warnings about unknown warning options
 # pragma clang diagnostic warning "-Wunknown-pragmas" // we want to see warnings about unknown pragmas
-#elif defined( __NVCOMPILER )
-# pragma diag_suppress 177 // Suppress: variable "..." was declared but never referenced
-# pragma diag_suppress 186 // Suppress: pointless comparison of unsigned integer with zero
-# pragma diag_suppress 941 // Suppress:  missing return statement at end of non-void function "..."
 #elif defined( __GNUC__ )
 # pragma GCC   diagnostic ignored "-Wunused-parameter"
 # pragma GCC   diagnostic ignored "-Wunused-function"

--- a/test/gsl-lite.t.hpp
+++ b/test/gsl-lite.t.hpp
@@ -69,6 +69,10 @@
 # pragma clang diagnostic ignored "-Wunused-member-function"
 # pragma clang diagnostic warning "-Wunknown-warning-option" // we want to see warnings about unknown warning options
 # pragma clang diagnostic warning "-Wunknown-pragmas" // we want to see warnings about unknown pragmas
+#elif defined( __NVCOMPILER )
+# pragma diag_suppress 177 // Suppress: variable "..." was declared but never referenced
+# pragma diag_suppress 186 // Suppress: pointless comparison of unsigned integer with zero
+# pragma diag_suppress 941 // Suppress:  missing return statement at end of non-void function "..."
 #elif defined( __GNUC__ )
 # pragma GCC   diagnostic ignored "-Wunused-parameter"
 # pragma GCC   diagnostic ignored "-Wunused-function"

--- a/test/lest_cpp03.hpp
+++ b/test/lest_cpp03.hpp
@@ -355,7 +355,7 @@ namespace lest
 
 #define lest_CASE( specification, proposition ) \
     static void lest_FUNCTION( lest::env & ); \
-    namespace { lest::add_test lest_REGISTRAR( specification, lest::test( proposition, lest_FUNCTION ) ); } \
+    static lest::add_test lest_REGISTRAR( specification, lest::test( proposition, lest_FUNCTION ) ); \
     static void lest_FUNCTION( lest_MAYBE_UNUSED( lest::env & lest_env ) )
 
 #define lest_ADD_TEST( specification, test ) \

--- a/test/lest_cpp03.hpp
+++ b/test/lest_cpp03.hpp
@@ -118,6 +118,14 @@
 # define lest_RESTORE_WARNINGS         /*empty*/
 #endif
 
+#if defined(__NVCOMPILER)
+# define lest_SUPPRESS_CONTROLLING_EXPRESSION_IS_CONSTANT _Pragma("diag_suppress 236")
+# define lest_RESTORE_CONTROLLING_EXPRESSION_IS_CONSTANT _Pragma("diag_default 236")
+#else
+# define lest_SUPPRESS_CONTROLLING_EXPRESSION_IS_CONSTANT
+# define lest_RESTORE_CONTROLLING_EXPRESSION_IS_CONSTANT
+#endif
+
 // Stringify:
 
 #define lest_STRINGIFY(  x )  lest_STRINGIFY_( x )
@@ -377,10 +385,12 @@ namespace lest
     do { \
         lest_TRY \
         { \
+            lest_SUPPRESS_CONTROLLING_EXPRESSION_IS_CONSTANT \
             if ( lest::result score = lest_DECOMPOSE( expr ) ) \
                 lest_THROW( lest::failure( lest_LOCATION, #expr, score.decomposition ) ); \
             else if ( lest_env.pass() ) \
                 lest::report( lest_env.os, lest::passing( lest_LOCATION, #expr, score.decomposition, lest_env.zen() ), lest_env.context() ); \
+            lest_RESTORE_CONTROLLING_EXPRESSION_IS_CONSTANT \
         } \
         lest_CATCH_ALL \
         { \
@@ -392,6 +402,7 @@ namespace lest
     do { \
         lest_TRY \
         { \
+            lest_SUPPRESS_CONTROLLING_EXPRESSION_IS_CONSTANT \
             if ( lest::result score = lest_DECOMPOSE( expr ) ) \
             { \
                 if ( lest_env.pass() ) \
@@ -399,6 +410,7 @@ namespace lest
             } \
             else \
                 lest_THROW( lest::failure( lest_LOCATION, lest::not_expr( #expr ), lest::not_expr( score.decomposition ) ) ); \
+            lest_RESTORE_CONTROLLING_EXPRESSION_IS_CONSTANT \
         } \
         lest_CATCH_ALL \
         { \


### PR DESCRIPTION
`gsl-lite` does not work out of the box with the NVHPC compilers on my system:
```
"include/gsl/gsl-lite.hpp", line 1394: error: identifier "__ORDER_LITTLE_ENDIAN__" is undefined
      little = __ORDER_LITTLE_ENDIAN__,
               ^

"include/gsl/gsl-lite.hpp", line 1395: error: identifier "__ORDER_BIG_ENDIAN__" is undefined
      big    = __ORDER_BIG_ENDIAN__,
               ^

"include/gsl/gsl-lite.hpp", line 1396: error: identifier "__BYTE_ORDER__" is undefined
      native = __BYTE_ORDER__
               ^
```

This is a minimal patch to recognise the NVHPC compilers as distinct from GCC and assume little-endian order for them.

I tried to build and run the full set of `gsl-lite` tests and examples; there were no errors but a few warnings are repeated many times. For example:
```
"gsl-lite/test/not_null.t.cpp", line 694: warning: variable "<unnamed>::__lest_registrar__694" was declared but never referenced
  CASE( "not_null<>: Allows to construct a const pointer from a not_null related pointer type (shared_ptr)" )
  ^
```