### PR TITLE
Use `gsl_Assert()` for invariant checks; fix `weak_ptr<>` conversion

### DIFF
--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -2625,26 +2625,23 @@ public:
     gsl_NODISCARD gsl_api gsl_constexpr14 element_type *
     get() const
     {
-        element_type * result = data_.ptr_.get();
-        gsl_Ensures( result != gsl_nullptr );
-        return result;
+        gsl_Assert( data_.ptr_ != gsl_nullptr );
+        return data_.ptr_.get();
     }
 #else
 # if gsl_CONFIG( NOT_NULL_GET_BY_CONST_REF )
     gsl_NODISCARD gsl_api gsl_constexpr14 T const &
     get() const
     {
-        T const & result = data_.ptr_;
-        gsl_Ensures( result != gsl_nullptr );
-        return result;
+        gsl_Assert( data_.ptr_ != gsl_nullptr );
+        return data_.ptr_;
     }
 # else
     gsl_NODISCARD gsl_api gsl_constexpr14 T
     get() const
     {
-        T result = data_.ptr_;
-        gsl_Ensures( result != gsl_nullptr );
-        return result;
+        gsl_Assert( data_.ptr_ != gsl_nullptr );
+        return data_.ptr_;
     }
 # endif
 #endif
@@ -2691,9 +2688,8 @@ public:
     &
 # endif
     {
-        U result( data_.ptr_ );
-        gsl_Ensures( result != gsl_nullptr );
-        return result;
+        gsl_Assert( data_.ptr_ != gsl_nullptr );
+        return U( data_.ptr_ );
     }
 # if gsl_HAVE( FUNCTION_REF_QUALIFIER )
     template< class U
@@ -2703,9 +2699,8 @@ public:
     gsl_NODISCARD gsl_api gsl_constexpr14 explicit
     operator U() &&
     {
-        U result( std::move( data_.ptr_ ) );
-        gsl_Ensures( result != gsl_nullptr );
-        return result;
+        gsl_Assert( data_.ptr_ != gsl_nullptr );
+        return U( std::move( data_.ptr_ ) );
     }
 # endif
 
@@ -2720,9 +2715,8 @@ public:
     &
 # endif
     {
-        U result( data_.ptr_ );
-        gsl_Ensures( result != gsl_nullptr );
-        return result;
+        gsl_Assert( data_.ptr_ != gsl_nullptr );
+        return data_.ptr_;
     }
 # if gsl_HAVE( FUNCTION_REF_QUALIFIER )
     template< class U
@@ -2732,9 +2726,8 @@ public:
     gsl_NODISCARD gsl_api gsl_constexpr14
     operator U() &&
     {
-        U result( std::move( data_.ptr_ ) );
-        gsl_Ensures( result != gsl_nullptr );
-        return result;
+        gsl_Assert( data_.ptr_ != gsl_nullptr );
+        return std::move( data_.ptr_ );
     }
 # endif
 #else // a.k.a. #if !( gsl_HAVE( MOVE_FORWARD ) && gsl_HAVE( TYPE_TRAITS ) && gsl_HAVE( DEFAULT_FUNCTION_TEMPLATE_ARG ) && gsl_HAVE( EXPLICIT ) )
@@ -2742,24 +2735,22 @@ public:
     gsl_NODISCARD gsl_api gsl_constexpr14
     operator U() const
     {
-        U result( data_.ptr_ );
-        gsl_Ensures( result != gsl_nullptr );
-        return result;
+        gsl_Assert( data_.ptr_ != gsl_nullptr );
+        return U( data_.ptr_ );
     }
 #endif // gsl_HAVE( MOVE_FORWARD ) && gsl_HAVE( TYPE_TRAITS ) && gsl_HAVE( DEFAULT_FUNCTION_TEMPLATE_ARG ) && gsl_HAVE( EXPLICIT )
 
     gsl_NODISCARD gsl_api gsl_constexpr14 T const &
     operator->() const
     {
-        T const & result( data_.ptr_ );
-        gsl_Ensures( result != gsl_nullptr );
-        return result;
+        gsl_Assert( data_.ptr_ != gsl_nullptr );
+        return data_.ptr_;
     }
 
     gsl_NODISCARD gsl_api gsl_constexpr14 element_type &
     operator*() const
     {
-        gsl_Expects( data_.ptr_ != gsl_nullptr );
+        gsl_Assert( data_.ptr_ != gsl_nullptr );
         return *data_.ptr_;
     }
 

--- a/test/not_null.t.cpp
+++ b/test/not_null.t.cpp
@@ -1205,17 +1205,19 @@ CASE( "not_null<>: Allows to convert to weak_ptr<T> from a not_null<shared_ptr<T
     EXPECT( q.lock().get() == raw );
 }
 
+// C++14 has ambiguity issues with constructors and conversion operators that were fixed in C++17,
+// cf. https://github.com/gsl-lite/gsl-lite/issues/275#issuecomment-678640600.
+// Also, Clang ≤ 5 may pretend to support C++17 but it still suffers from the conversion ambiguity.
+#if gsl_CPP17_OR_GREATER && ! ( gsl_BETWEEN(gsl_COMPILER_CLANG_VERSION, 1, 600) || gsl_BETWEEN(gsl_COMPILER_APPLECLANG_VERSION, 1, 1000) )
 CASE( "not_null<>: Allows to convert from a not_null<shared_ptr<T>> to a user-defined type with explicit conversion constructor" )
 {
     shared_ptr< int > pi = std::make_shared< int >(12);
     not_null< shared_ptr< int > > p( std::move(pi) );
 
-#if gsl_CPP11_OR_GREATER
     ExplicitFromShared< int > q(p);
-#else
-    ExplicitFromShared< int > q(p); // in C++98, we cannot differentiate between implicit and explicit cases, so conversion is always explicit
-#endif
+    (void) q;
 }
+#endif // gsl_CPP17_OR_GREATER
 
 CASE( "not_null<>: Allows to construct a not_null<shared_ptr<const T>> from a not_null<unique_ptr<T>>" )
 {


### PR DESCRIPTION
The `not_null<>` conversion operators previously made the unfounded and unnecessary assumption that the type being converted to is also pointer-like. This was a problem when converting `not_null<shared_ptr<T>>` to `weak_ptr<T>`, which is not pointer-like despite the name.

Also, the use of `gsl_Ensures()` in the member functions of `not_null<>` was misguided; these checks express class invariants, not postconditions, and should therefore be written using `gsl_Assert()`.

Fixes #310.