### PR TITLE
Move `lexicographical_compare()`, `equal()` to `detail` namespace

### DIFF
--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -465,7 +465,8 @@
 // AppleClang 11.0.0  __apple_build_version__ == 11000033  gsl_COMPILER_APPLECLANG_VERSION == 1100  (Xcode 11.1, 11.2, 11.3, 11.3.1) (LLVM  8.0.0)
 // AppleClang 11.0.3  __apple_build_version__ == 11030032  gsl_COMPILER_APPLECLANG_VERSION == 1103  (Xcode 11.4, 11.4.1, 11.5, 11.6) (LLVM  9.0.0)
 // AppleClang 12.0.0  __apple_build_version__ == 12000032  gsl_COMPILER_APPLECLANG_VERSION == 1200  (Xcode 12.0–12.4)                (LLVM 10.0.0)
-// AppleClang 12.0.5  __apple_build_version__ == 12050022  gsl_COMPILER_APPLECLANG_VERSION == 1205  (Xcode 12.5)                     (LLVM 10.0.0)
+// AppleClang 12.0.5  __apple_build_version__ == 12050022  gsl_COMPILER_APPLECLANG_VERSION == 1205  (Xcode 12.5)                     (LLVM 11.1.0)
+// AppleClang 13.0.0  __apple_build_version__ == 13000029  gsl_COMPILER_APPLECLANG_VERSION == 1300  (Xcode 13.0)                     (LLVM 12.0.0)
 
 #if defined( __apple_build_version__ )
 # define gsl_COMPILER_APPLECLANG_VERSION  gsl_COMPILER_VERSION( __clang_major__, __clang_minor__, __clang_patchlevel__ )
@@ -1690,11 +1691,11 @@ typedef gsl_CONFIG_INDEX_TYPE diff;
 #if gsl_COMPILER_NVHPC_VERSION
 // Suppress "controlling expression is constant" warning when using gsl_Expects,
 // gsl_Ensures, gsl_Assert, gsl_FailFast and so on.
-# define gsl_SUPPRESS_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT _Pragma("diag_suppress 236")
-# define gsl_RESTORE_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT _Pragma("diag_default 236")
+# define gsl_SUPPRESS_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT_ _Pragma("diag_suppress 236")
+# define gsl_RESTORE_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT_ _Pragma("diag_default 236")
 #else
-# define gsl_SUPPRESS_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT
-# define gsl_RESTORE_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT
+# define gsl_SUPPRESS_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT_
+# define gsl_RESTORE_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT_
 #endif
 #if defined( gsl_CONFIG_CONTRACT_VIOLATION_CALLS_HANDLER )
 # define   gsl_CONTRACT_CHECK_( str, x )  ( ( x ) ? static_cast<void>(0) : ::gsl::fail_fast_assert_handler( #x, str, __FILE__, __LINE__ ) )
@@ -1711,9 +1712,9 @@ typedef gsl_CONFIG_INDEX_TYPE diff;
 #endif
 # define  gsl_FAILFAST_()                 ( __trap() )
 #elif defined( gsl_CONFIG_CONTRACT_VIOLATION_ASSERTS )
-# define   gsl_CONTRACT_CHECK_( str, x )  gsl_SUPPRESS_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT assert( str && ( x ) ) gsl_RESTORE_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT
+# define   gsl_CONTRACT_CHECK_( str, x )  gsl_SUPPRESS_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT_ assert( str && ( x ) ) gsl_RESTORE_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT_
 # if ! defined( NDEBUG )
-#  define  gsl_FAILFAST_()                (gsl_SUPPRESS_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT assert( ! "GSL: failure" ) gsl_RESTORE_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT, ::gsl::detail::fail_fast_terminate() )
+#  define  gsl_FAILFAST_()                (gsl_SUPPRESS_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT_ assert( ! "GSL: failure" ) gsl_RESTORE_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT_, ::gsl::detail::fail_fast_terminate() )
 # else
 #  define  gsl_FAILFAST_()                ( ::gsl::detail::fail_fast_terminate() )
 # endif
@@ -1725,10 +1726,10 @@ typedef gsl_CONFIG_INDEX_TYPE diff;
 #  define  gsl_FAILFAST_()                ( gsl_TRAP_() )
 # endif
 #elif defined( gsl_CONFIG_CONTRACT_VIOLATION_THROWS )
-# define   gsl_CONTRACT_CHECK_( str, x )  gsl_SUPPRESS_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT ( ( x ) ? static_cast<void>(0) : ::gsl::detail::fail_fast_throw( str ": '" #x "' at " __FILE__ ":" gsl_STRINGIFY(__LINE__) ) ) gsl_RESTORE_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT
+# define   gsl_CONTRACT_CHECK_( str, x )  gsl_SUPPRESS_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT_ ( ( x ) ? static_cast<void>(0) : ::gsl::detail::fail_fast_throw( str ": '" #x "' at " __FILE__ ":" gsl_STRINGIFY(__LINE__) ) ) gsl_RESTORE_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT_
 # define   gsl_FAILFAST_()                ( ::gsl::detail::fail_fast_throw( "GSL: failure at " __FILE__ ":" gsl_STRINGIFY(__LINE__) ) )
 #else // defined( gsl_CONFIG_CONTRACT_VIOLATION_TERMINATES ) [default]
-# define   gsl_CONTRACT_CHECK_( str, x )  gsl_SUPPRESS_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT ( ( x ) ? static_cast<void>(0) : ::gsl::detail::fail_fast_terminate() ) gsl_RESTORE_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT
+# define   gsl_CONTRACT_CHECK_( str, x )  gsl_SUPPRESS_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT_ ( ( x ) ? static_cast<void>(0) : ::gsl::detail::fail_fast_terminate() ) gsl_RESTORE_NVHPC_CONTROLLING_EXPRESSION_IS_CONSTANT_
 # define   gsl_FAILFAST_()                ( ::gsl::detail::fail_fast_terminate() )
 #endif
 
@@ -2182,7 +2183,7 @@ namespace detail {
     {
         return detail::is_negative( t, std::is_signed<T>() ) == detail::is_negative( u, std::is_signed<U>() );
     }
-# endif // gsl_COMPILER_NVCC_VERSION
+# endif // gsl_COMPILER_NVCC_VERSION || gsl_COMPILER_NVHPC_VERSION
 
 } // namespace detail
 

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -1129,7 +1129,7 @@ class span;
 
 // C++98 emulation:
 
-namespace std98 {
+namespace detail {
 
 // We implement `equal()` and `lexicographical_compare()` here to avoid having to pull in the <algorithm> header.
 template< class InputIt1, class InputIt2 >
@@ -1154,7 +1154,7 @@ bool lexicographical_compare( InputIt1 first1, InputIt1 last1, InputIt2 first2, 
     return first1 == last1 && first2 != last2;
 }
 
-} // namespace std98
+} // namespace detail
 
 // C++11 emulation:
 
@@ -3949,14 +3949,14 @@ gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_NODISCARD inline gsl_constexpr bool operator==( span<T> const & l, span<U> const & r )
 {
     return  l.size()  == r.size()
-        && (l.begin() == r.begin() || std98::equal( l.begin(), l.end(), r.begin() ) );
+        && (l.begin() == r.begin() || detail::equal( l.begin(), l.end(), r.begin() ) );
 }
 
 template< class T, class U >
 gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_NODISCARD inline gsl_constexpr bool operator< ( span<T> const & l, span<U> const & r )
 {
-    return std98::lexicographical_compare( l.begin(), l.end(), r.begin(), r.end() );
+    return detail::lexicographical_compare( l.begin(), l.end(), r.begin(), r.end() );
 }
 
 # else // a.k.a. !gsl_CONFIG( ALLOWS_NONSTRICT_SPAN_COMPARISON )
@@ -3966,14 +3966,14 @@ gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_NODISCARD inline gsl_constexpr bool operator==( span<T> const & l, span<T> const & r )
 {
     return  l.size()  == r.size()
-        && (l.begin() == r.begin() || std98::equal( l.begin(), l.end(), r.begin() ) );
+        && (l.begin() == r.begin() || detail::equal( l.begin(), l.end(), r.begin() ) );
 }
 
 template< class T >
 gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_NODISCARD inline gsl_constexpr bool operator< ( span<T> const & l, span<T> const & r )
 {
-    return std98::lexicographical_compare( l.begin(), l.end(), r.begin(), r.end() );
+    return detail::lexicographical_compare( l.begin(), l.end(), r.begin(), r.end() );
 }
 # endif // gsl_CONFIG( ALLOWS_NONSTRICT_SPAN_COMPARISON )
 
@@ -4591,7 +4591,7 @@ operator==( basic_string_span<T> const & l, U const & u ) gsl_noexcept
     const basic_string_span< typename std11::add_const<T>::type > r( u );
 
     return l.size() == r.size()
-        && std98::equal( l.begin(), l.end(), r.begin() );
+        && detail::equal( l.begin(), l.end(), r.begin() );
 }
 
 template< class T, class U >
@@ -4601,7 +4601,7 @@ operator<( basic_string_span<T> const & l, U const & u ) gsl_noexcept
 {
     const basic_string_span< typename std11::add_const<T>::type > r( u );
 
-    return std98::lexicographical_compare( l.begin(), l.end(), r.begin(), r.end() );
+    return detail::lexicographical_compare( l.begin(), l.end(), r.begin(), r.end() );
 }
 
 #if gsl_HAVE( DEFAULT_FUNCTION_TEMPLATE_ARG )
@@ -4616,7 +4616,7 @@ operator==( U const & u, basic_string_span<T> const & r ) gsl_noexcept
     const basic_string_span< typename std11::add_const<T>::type > l( u );
 
     return l.size() == r.size()
-        && std98::equal( l.begin(), l.end(), r.begin() );
+        && detail::equal( l.begin(), l.end(), r.begin() );
 }
 
 template< class T, class U
@@ -4628,7 +4628,7 @@ operator<( U const & u, basic_string_span<T> const & r ) gsl_noexcept
 {
     const basic_string_span< typename std11::add_const<T>::type > l( u );
 
-    return std98::lexicographical_compare( l.begin(), l.end(), r.begin(), r.end() );
+    return detail::lexicographical_compare( l.begin(), l.end(), r.begin(), r.end() );
 }
 #endif
 
@@ -4640,7 +4640,7 @@ gsl_NODISCARD inline gsl_constexpr14 bool
 operator==( basic_string_span<T> const & l, basic_string_span<T> const & r ) gsl_noexcept
 {
     return l.size() == r.size()
-        && std98::equal( l.begin(), l.end(), r.begin() );
+        && detail::equal( l.begin(), l.end(), r.begin() );
 }
 
 template< class T >
@@ -4648,7 +4648,7 @@ gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_NODISCARD inline gsl_constexpr14 bool
 operator<( basic_string_span<T> const & l, basic_string_span<T> const & r ) gsl_noexcept
 {
-    return std98::lexicographical_compare( l.begin(), l.end(), r.begin(), r.end() );
+    return detail::lexicographical_compare( l.begin(), l.end(), r.begin(), r.end() );
 }
 
 #endif // gsl_CONFIG( ALLOWS_NONSTRICT_SPAN_COMPARISON )

--- a/test/emulation.t.cpp
+++ b/test/emulation.t.cpp
@@ -34,15 +34,15 @@ CASE( "equal()" )
 {
     char const* arg1 = "foo";
     char const* arg2 = "fou";
-    EXPECT(   std98::equal( arg1, arg1 + std::strlen( arg1 ), arg1 ) );
-    EXPECT( ! std98::equal( arg1, arg1 + std::strlen( arg1 ), arg2 ) );
-    EXPECT( ! std98::equal( arg2, arg2 + std::strlen( arg2 ), arg1 ) );
+    EXPECT(   detail::equal( arg1, arg1 + std::strlen( arg1 ), arg1 ) );
+    EXPECT( ! detail::equal( arg1, arg1 + std::strlen( arg1 ), arg2 ) );
+    EXPECT( ! detail::equal( arg2, arg2 + std::strlen( arg2 ), arg1 ) );
 
     std::istringstream sstr1a1( "foo" ), sstr1a2( "foo" ), sstr1b( "foo" ), sstr1c( "foo" );
     std::istringstream sstr2b( "fou" ), sstr2c( "fou" );
-    EXPECT(   std98::equal( std::istreambuf_iterator<char>( sstr1a1 ), std::istreambuf_iterator<char>(), std::istreambuf_iterator<char>( sstr1a2 ) ) );
-    EXPECT( ! std98::equal( std::istreambuf_iterator<char>( sstr1b ), std::istreambuf_iterator<char>(), std::istreambuf_iterator<char>( sstr2b ) ) );
-    EXPECT( ! std98::equal( std::istreambuf_iterator<char>( sstr2c ), std::istreambuf_iterator<char>(), std::istreambuf_iterator<char>( sstr1c ) ) );
+    EXPECT(   detail::equal( std::istreambuf_iterator<char>( sstr1a1 ), std::istreambuf_iterator<char>(), std::istreambuf_iterator<char>( sstr1a2 ) ) );
+    EXPECT( ! detail::equal( std::istreambuf_iterator<char>( sstr1b ), std::istreambuf_iterator<char>(), std::istreambuf_iterator<char>( sstr2b ) ) );
+    EXPECT( ! detail::equal( std::istreambuf_iterator<char>( sstr2c ), std::istreambuf_iterator<char>(), std::istreambuf_iterator<char>( sstr1c ) ) );
 }
 
 template < typename T, std::size_t N >
@@ -61,13 +61,13 @@ CASE( "lexicographical_compare()" )
     };
     for ( std::size_t i = 0, n = arraySize( less ); i != n; ++i )
     {
-        EXPECT( std98::lexicographical_compare( less[i].first, less[i].first + std::strlen( less[i].first ), less[i].second, less[i].second + std::strlen( less[i].second ) ));
+        EXPECT( detail::lexicographical_compare( less[i].first, less[i].first + std::strlen( less[i].first ), less[i].second, less[i].second + std::strlen( less[i].second ) ));
 
         std::istringstream sstr1( less[i].first );
         std::istringstream sstr2( less[i].second );
         std::istreambuf_iterator<char> it1( sstr1 ), it1End;
         std::istreambuf_iterator<char> it2( sstr2 ), it2End;
-        EXPECT( std98::lexicographical_compare( it1, it1End, it2, it2End ));
+        EXPECT( detail::lexicographical_compare( it1, it1End, it2, it2End ));
     }
 
     std::pair<char const*, char const*> notLess[] = {
@@ -80,13 +80,13 @@ CASE( "lexicographical_compare()" )
     };
     for ( std::size_t i = 0, n = arraySize( less ); i != n; ++i )
     {
-        EXPECT( ! std98::lexicographical_compare( notLess[i].first, notLess[i].first + std::strlen( notLess[i].first ), notLess[i].second, notLess[i].second + std::strlen( notLess[i].second ) ));
+        EXPECT( ! detail::lexicographical_compare( notLess[i].first, notLess[i].first + std::strlen( notLess[i].first ), notLess[i].second, notLess[i].second + std::strlen( notLess[i].second ) ));
 
         std::istringstream sstr1( notLess[i].first );
         std::istringstream sstr2( notLess[i].second );
         std::istreambuf_iterator<char> it1( sstr1 ), it1End;
         std::istreambuf_iterator<char> it2( sstr2 ), it2End;
-        EXPECT( ! std98::lexicographical_compare( it1, it1End, it2, it2End ));
+        EXPECT( ! detail::lexicographical_compare( it1, it1End, it2, it2End ));
     }
 }
 


### PR DESCRIPTION
These functions are required only for deprecated features of `span<>` and related classes. We do not want to commit to providing these forever as part of the public interface; therefore we put them in `gsl::detail` instead of  `gsl::std98`.