### PR TITLE
Add `gsl::is_valid()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,6 +973,7 @@ not_null<>: Allows to compare less than another not_null of the same type
 not_null<>: Allows to compare less than or equal to another not_null of the same type
 not_null<>: Allows to compare greater than another not_null of the same type
 not_null<>: Allows to compare greater than or equal to another not_null of the same type
+not_null<>: Allows to check whether object is valid
 not_null<>: Allows to compare equal to a raw pointer of the same type
 not_null<>: Allows to compare unequal to a raw pointer of the same type
 not_null<>: Allows to compare less than a raw pointer of the same type

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -3218,16 +3218,31 @@ gsl_NODISCARD gsl_api gsl_constexpr T const & as_nullable( T const & p ) gsl_noe
 }
 #endif // gsl_HAVE( MOVE_FORWARD )
 template< class T >
-gsl_NODISCARD gsl_api gsl_constexpr14 T const & as_nullable( not_null<T> const & p )
+gsl_NODISCARD gsl_api gsl_constexpr14 T const &
+as_nullable( not_null<T> const & p )
 {
     T const & result = detail::not_null_accessor<T>::get( p );
     gsl_Expects( result != gsl_nullptr );
     return result;
 }
 template< class T >
-gsl_NODISCARD gsl_api gsl_constexpr T* as_nullable( not_null<T*> p ) gsl_noexcept
+gsl_NODISCARD gsl_api gsl_constexpr T*
+as_nullable( not_null<T*> p ) gsl_noexcept
 {
     return detail::not_null_accessor<T*>::get( p );
+}
+
+template< class T >
+gsl_NODISCARD gsl_api gsl_constexpr bool
+is_valid( not_null<T> const & p )
+{
+    return detail::not_null_accessor<T>::get( p ) != gsl_nullptr;
+}
+template< class T >
+gsl_NODISCARD gsl_api gsl_constexpr bool
+is_valid( not_null<T*> const & )
+{
+    return true;
 }
 
 } // namespace no_adl

--- a/test/not_null.t.cpp
+++ b/test/not_null.t.cpp
@@ -459,6 +459,21 @@ CASE( "not_null<>: Allows dereferencing (raw pointer)" )
     EXPECT( *p == i );
 }
 
+CASE( "not_null<>: Allows to check whether object is valid (raw pointer)" )
+{
+    int i = 12;
+    not_null< int* > p( &i );
+
+    EXPECT( gsl::is_valid( p ) );
+
+#if gsl_HAVE( MOVE_FORWARD )
+    not_null< int* > q( std::move( p ) );
+
+    EXPECT( gsl::is_valid( p ) ); // for raw pointers, moving `not_null<>` just makes a copy
+    EXPECT( gsl::is_valid( q ) );
+#endif
+}
+
 #if gsl_HAVE( MOVE_FORWARD )
 template< class T >
 void move_to( T& dest, T& src )
@@ -768,6 +783,19 @@ CASE( "not_null<>: Allows dereferencing (shared_ptr)" )
     not_null< shared_ptr< int > > p( pi );
 
     EXPECT( *p == *pi );
+}
+
+CASE( "not_null<>: Allows to check whether object is valid (shared_ptr)" )
+{
+    shared_ptr< int > pi = std::make_shared< int >(12);
+    not_null< shared_ptr< int > > p( pi );
+
+    EXPECT( gsl::is_valid( p ) );
+
+    not_null< shared_ptr< int > > q( std::move( p ) );
+
+    EXPECT_NOT( gsl::is_valid( p ) );
+    EXPECT(     gsl::is_valid( q ) );
 }
 
 #endif // gsl_HAVE( SHARED_PTR )
@@ -1124,10 +1152,23 @@ CASE( "not_null<>: Allows indirect member access (unique_ptr)" )
 CASE( "not_null<>: Allows dereferencing (unique_ptr)" )
 {
     int i = 12;
-    unique_ptr< int > pi = my_make_unique< int >(i);
+    unique_ptr< int > pi = my_make_unique< int >(12);
     not_null< unique_ptr< int > > p( std::move(pi) );
 
     EXPECT( *p == i );
+}
+
+CASE( "not_null<>: Allows to check whether object is valid (unique_ptr)" )
+{
+    unique_ptr< int > pi = my_make_unique< int >( 12 );
+    not_null< unique_ptr< int > > p( std::move(pi) );
+
+    EXPECT( gsl::is_valid( p ) );
+
+    not_null< unique_ptr< int > > q( std::move( p ) );
+
+    EXPECT_NOT( gsl::is_valid( p ) );
+    EXPECT(     gsl::is_valid( q ) );
 }
 
 #endif // gsl_HAVE( UNIQUE_PTR )
@@ -1411,14 +1452,6 @@ CASE( "not_null<>: Allows to compare greater than or equal to another not_null o
 }
 
 // raw pointer
-
-CASE( "not_null<>: Allows to check whether object is valid" )
-{
-    NotNull _;
-
-    EXPECT(gsl::is_valid(_.p1()));
-    EXPECT(gsl::is_valid(_.p2()));
-}
 
 CASE( "not_null<>: Allows to compare equal to a raw pointer of the same type" )
 {

--- a/test/not_null.t.cpp
+++ b/test/not_null.t.cpp
@@ -1412,6 +1412,14 @@ CASE( "not_null<>: Allows to compare greater than or equal to another not_null o
 
 // raw pointer
 
+CASE( "not_null<>: Allows to check whether object is valid" )
+{
+    NotNull _;
+
+    EXPECT(gsl::is_valid(_.p1()));
+    EXPECT(gsl::is_valid(_.p2()));
+}
+
 CASE( "not_null<>: Allows to compare equal to a raw pointer of the same type" )
 {
     NotNull _;


### PR DESCRIPTION
`gsl::is_valid()` permits explicitly checking for the moved-from state of `not_null<>`.