### PR TITLE
Fix GCC12 dangling pointer error in tests

### DIFF
--- a/test/span.t.cpp
+++ b/test/span.t.cpp
@@ -401,6 +401,7 @@ gsl_constexpr14 int use_span_with_array( int const (&array)[3], span<int const> 
 
     int array2[3] = { 0, 0, 0 };
     span<int> sp2 = span<int>( array2 );
+    span<int const> spsave = sp;
     sp = sp2;
 #if gsl_CPP17_OR_GREATER
     array2[0] = 1;
@@ -408,6 +409,7 @@ gsl_constexpr14 int use_span_with_array( int const (&array)[3], span<int const> 
 #endif
     sp2[1] = 2;
     gsl_Assert( array2[1] == 2 );
+    sp = spsave;
     return 0;
 }
 


### PR DESCRIPTION
On GCC 12 (pre-release), this fixes:

```
[ 46%] Building CXX object test/CMakeFiles/gsl-lite-v0-cpp20.t.dir/issue.t.cpp.o
cd /builddir/build/BUILD/gsl-lite-0.40.0/redhat-linux-build/test && /usr/bin/g++ -Dgsl_CONFIG_CONTRACT_CHECKING_AUDIT -Dgsl_CONFIG_CONTRACT_VIOLATION_THROWS -Dgsl_CONFIG_UNENFORCED_CONTRACTS_ELIDE -Dgsl_TESTING_ -I/builddir/build/BUILD/gsl-lite-0.40.0/include -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -Werror -Wall -Wextra -Wconversion -Wsign-conversion -fno-elide-constructors -fstrict-aliasing -Wstrict-aliasing=2 -pedantic -Wno-long-long -Wno-error=array-bounds -std=c++20 -Winvalid-pch -include /builddir/build/BUILD/gsl-lite-0.40.0/redhat-linux-build/test/CMakeFiles/gsl-lite-v0-cpp20.t.dir/cmake_pch.hxx -MD -MT test/CMakeFiles/gsl-lite-v0-cpp20.t.dir/issue.t.cpp.o -MF CMakeFiles/gsl-lite-v0-cpp20.t.dir/issue.t.cpp.o.d -o CMakeFiles/gsl-lite-v0-cpp20.t.dir/issue.t.cpp.o -c /builddir/build/BUILD/gsl-lite-0.40.0/test/issue.t.cpp
In file included from /builddir/build/BUILD/gsl-lite-0.40.0/test/gsl-lite.t.hpp:38,
                 from /builddir/build/BUILD/gsl-lite-0.40.0/redhat-linux-build/test/CMakeFiles/gsl-lite-v1-no-exc-cpp98.t.dir/cmake_pch.hxx:5,
                 from <command-line>:
In member function 'gsl::span<int const>::operator=(gsl::span<int const>)',
    inlined from 'use_span_with_array(int const (&) [3], gsl::span<int const>)' at /builddir/build/BUILD/gsl-lite-0.40.0/test/span.t.cpp:404:10:
/builddir/build/BUILD/gsl-lite-0.40.0/include/gsl/gsl-lite.hpp:3882:15: error: storing the address of local variable 'array2' in 'sp_6(D)->last_' [-Werror=dangling-pointer=]
 3882 |         last_ = other.last_;
      |         ~~~~~~^~~~~~~~~~~~~
/builddir/build/BUILD/gsl-lite-0.40.0/test/span.t.cpp: In function 'use_span_with_array(int const (&) [3], gsl::span<int const>)':
/builddir/build/BUILD/gsl-lite-0.40.0/test/span.t.cpp:402:9: note: 'array2' declared here
  402 |     int array2[3] = { 0, 0, 0 };
      |         ^~~~~~
/builddir/build/BUILD/gsl-lite-0.40.0/test/span.t.cpp:402:9: note: 'sp_6(D)' declared here
```

It looks like the dangling pointer would never be dereferenced in practice, but this patch eliminates the compiler error by copying the span and restoring it at the end of `use_span_with_array` so the local stack pointer cannot leak to the caller.