### PR TITLE
add SYSTEM to target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(
     ${package_nspace}::${package_name} ALIAS ${package_name} )
 target_include_directories(
     ${package_name}
+    SYSTEM
     INTERFACE
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>" )
@@ -89,6 +90,7 @@ add_library(
     ${package_nspace}::${package_name}-v0 ALIAS ${package_name}-v0 )
 target_include_directories(
     ${package_name}-v0
+    SYSTEM
     INTERFACE
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>" )
@@ -104,6 +106,7 @@ add_library(
     ${package_nspace}::${package_name}-v1 ALIAS ${package_name}-v1 )
 target_include_directories(
     ${package_name}-v1
+    SYSTEM
     INTERFACE
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>" )


### PR DESCRIPTION
In order to let compilers skip warnings caused by
gsl-lite. (e.g. `clang`s `-Wweak-vtables` is triggered by `fail_fast`)

See https://github.com/mrahn/test_gsl_lite_weak_vtables for a usage that triggers `-Wweak-vtables`
