### PR TITLE
Fix `not_null_ic` copy construction

### DIFF
--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -2660,8 +2660,8 @@ public:
         , typename std::enable_if< ( std::is_constructible<T, U>::value ), int >::type = 0
 #  endif
     >
-    gsl_api gsl_constexpr14 explicit not_null( U other )
-    : data_( T( std::move( other ) ) )
+    gsl_api gsl_constexpr14 explicit not_null( U && other )
+    : data_( T( std::forward<U>( other ) ) )
     {
         gsl_Expects( data_.ptr_ != gsl_nullptr );
     }
@@ -2682,8 +2682,8 @@ public:
         // We *have* to use SFINAE with an NTTP arg here, otherwise the overload is ambiguous.
         , typename std::enable_if< ( std::is_constructible<T, U>::value && !std::is_convertible<U, T>::value ), int >::type = 0
     >
-    gsl_api gsl_constexpr14 explicit not_null( U other )
-    : data_( T( std::move( other ) ) )
+    gsl_api gsl_constexpr14 explicit not_null( U && other )
+    : data_( T( std::forward<U>( other ) ) )
     {
         gsl_Expects( data_.ptr_ != gsl_nullptr );
     }


### PR DESCRIPTION
Without this change, copy construction caused infinite recursion.

Reproduction including a toggle between old and new behavior: https://godbolt.org/z/o9W19o9nh.