### PR TITLE
Add `gsl_CONFIG_VALIDATES_UNENFORCED_CONTRACT_EXPRESSIONS` config switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,14 @@ of configuration, i.e. due to definition of `gsl_CONFIG_CONTRACT_CHECKING_OFF`, 
   Contract checks disabled by configuration will be discarded. **This is the default.**  
     
   Note that `gsl_FailFast()` calls are never discarded.
+  
+  Even for discarded contract checks, *gsl-lite* will by default still verify that the contract check forms a valid Boolean
+  expression by using the C++11 features `decltype()` and `static_assert()`. This may lead to problems if the contract check
+  expression cannot be used in an unevaluated context, for instance, when using a lambda expression in C++11/14/17.
+  
+  The compile-time verification of contract check expressions is controlled by the configuration macro
+  `gsl_CONFIG_VALIDATES_UNENFORCED_CONTRACT_EXPRESSIONS`, which defaults to *`1`*. To suppress the verification, define
+  `gsl_CONFIG_VALIDATES_UNENFORCED_CONTRACT_EXPRESSIONS=0`.
 
 - **`gsl_CONFIG_UNENFORCED_CONTRACTS_ASSUME`**  
   For contracts expressed with `gsl_Expects()`, `gsl_Ensures()`, and `gsl_Assert()` which are not checked as a result of

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -301,6 +301,15 @@
 #endif
 #define gsl_CONFIG_NARROW_THROWS_ON_TRUNCATION_()  gsl_CONFIG_NARROW_THROWS_ON_TRUNCATION
 
+#if defined( gsl_CONFIG_VALIDATES_UNENFORCED_CONTRACT_EXPRESSIONS )
+# if ! gsl_CHECK_CFG_TOGGLE_VALUE_( gsl_CONFIG_VALIDATES_UNENFORCED_CONTRACT_EXPRESSIONS )
+#  pragma message ("invalid configuration value gsl_CONFIG_VALIDATES_UNENFORCED_CONTRACT_EXPRESSIONS=" gsl_STRINGIFY(gsl_CONFIG_VALIDATES_UNENFORCED_CONTRACT_EXPRESSIONS) ", must be 0 or 1")
+# endif
+#else
+# define gsl_CONFIG_VALIDATES_UNENFORCED_CONTRACT_EXPRESSIONS  1  // default
+#endif
+#define gsl_CONFIG_VALIDATES_UNENFORCED_CONTRACT_EXPRESSIONS_()  gsl_CONFIG_VALIDATES_UNENFORCED_CONTRACT_EXPRESSIONS
+
 #if defined( gsl_CONFIG_CONTRACT_CHECKING_EXPECTS_OFF )
 # if ! gsl_CHECK_CFG_NO_VALUE_( gsl_CONFIG_CONTRACT_CHECKING_EXPECTS_OFF )
 #  pragma message ("invalid configuration value gsl_CONFIG_CONTRACT_CHECKING_EXPECTS_OFF=" gsl_STRINGIFY(gsl_CONFIG_CONTRACT_CHECKING_EXPECTS_OFF) "; macro must be defined without value")
@@ -554,7 +563,8 @@
 // AppleClang 12.0.5  __apple_build_version__ == 12050022  gsl_COMPILER_APPLECLANG_VERSION == 1205  (Xcode 12.5)                     (LLVM 11.1.0)
 // AppleClang 13.0.0  __apple_build_version__ == 13000029  gsl_COMPILER_APPLECLANG_VERSION == 1300  (Xcode 13.0–13.2.1)              (LLVM 12.0.0)
 // AppleClang 13.1.6  __apple_build_version__ == 13160021  gsl_COMPILER_APPLECLANG_VERSION == 1316  (Xcode 13.3–13.4.1)              (LLVM 13.0.0)
-// AppleClang 14.0.0  __apple_build_version__ == 14000029  gsl_COMPILER_APPLECLANG_VERSION == 1400  (Xcode 14.0)                     (LLVM 14.0.0)
+// AppleClang 14.0.0  __apple_build_version__ == 14000029  gsl_COMPILER_APPLECLANG_VERSION == 1400  (Xcode 14.0–14.2)                (LLVM 14.0.0)
+// AppleClang 14.0.0  __apple_build_version__ == 14030022  gsl_COMPILER_APPLECLANG_VERSION == 1403  (Xcode 14.3)                     (LLVM 15.0.0)
 
 #if defined( __apple_build_version__ )
 # define gsl_COMPILER_APPLECLANG_VERSION  gsl_COMPILER_VERSION( __clang_major__, __clang_minor__, __clang_patchlevel__ )
@@ -1726,7 +1736,7 @@ typedef gsl_CONFIG_INDEX_TYPE diff;
 // GSL.assert: assertions
 //
 
-#if gsl_HAVE( TYPE_TRAITS )
+#if gsl_HAVE( TYPE_TRAITS ) && gsl_CONFIG( VALIDATES_UNENFORCED_CONTRACT_EXPRESSIONS )
 # define gsl_ELIDE_( x )  static_assert( ::std::is_constructible<bool, decltype( x )>::value, "argument of contract check must be convertible to bool" )
 #else
 # define gsl_ELIDE_( x )


### PR DESCRIPTION
Rationale is explained in updates to README.md.