### PR TITLE
respect libc++ configuration option to disable wchar_t

### DIFF
--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -416,7 +416,7 @@
 
 // Presence of wide character support:
 
-#ifdef __DJGPP__
+#if defined(__DJGPP__) || (defined(_LIBCPP_VERSION) && defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS))
 # define gsl_HAVE_WCHAR 0
 #else
 # define gsl_HAVE_WCHAR 1


### PR DESCRIPTION
libc++ can be configured not to support `wchar_t`. For example, the [open-source LLVM toolchain for 32bit ARM](https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm) is configured this way (refer to it's [CMakeLists.txt](https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/blob/fb3fb9358f90a49167332ff4abe41e0301cb0fe2/CMakeLists.txt#L398)). This PR sets `gsl_HAVE_WCHAR` correspondingly, allowing the library to be used in such toolchains.