### PR TITLE
Deprecate `string_span` and `zstring_span` and prepare for removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Macro                                                                           
 ------------------------------------------------------------------------------------:|:---------------------------------------------------------|-------------------|-|
 [`gsl_FEATURE_OWNER_MACRO`](#gsl_feature_owner_macro1)                               | 1                                                        | 0                 | an unprefixed macro `Owner()` may interfere with user code |
 [`gsl_FEATURE_GSL_LITE_NAMESPACE`](#gsl_feature_gsl_lite_namespace0)                 | 0                                                        | 1                 | cf. [Using *gsl-lite* in libraries](#using-gsl-lite-in-libraries) |
-[`gsl_CONFIG_DEPRECATE_TO_LEVEL`](#gsl_config_deprecate_to_level0)                   | 0                                                        | 6                 | |
+[`gsl_CONFIG_DEPRECATE_TO_LEVEL`](#gsl_config_deprecate_to_level0)                   | 0                                                        | 8                 | |
 [`gsl_CONFIG_INDEX_TYPE`](#gsl_config_index_typegsl_config_span_index_type)          | `gsl_CONFIG_SPAN_INDEX_TYPE` (defaults to `std::size_t`) | `std::ptrdiff_t`  | the GSL specifies `gsl::index` to be a signed type, and M-GSL also uses `std::ptrdiff_t` |
 [`gsl_CONFIG_ALLOWS_SPAN_COMPARISON`](#gsl_config_allows_span_comparison1)           | 1                                                        | 0                 | C++20 `std::span<>` does not support comparison because semantics (deep vs. shallow) are unclear |
 [`gsl_CONFIG_NOT_NULL_EXPLICIT_CTOR`](#gsl_config_not_null_explicit_ctor0)           | 0                                                        | 1                 | cf. reasoning in [M-GSL/#395](https://github.com/Microsoft/GSL/issues/395) (note that `not_null<>` in M-GSL has an implicit constructor, cf. [M-GSL/#699](https://github.com/Microsoft/GSL/issues/699)) |
@@ -680,6 +680,7 @@ The following features are deprecated since the indicated version. See macro [`g
 
 Version | Level | Feature / Notes |
 -------:|:-----:|:----------------|
+0.41.0  |   7   | `string_span<>`, `zstring_span<>` and related types |
 0.37.0  |   6   | `as_writeable_bytes()`, call indexing for spans, and `span::at()` |
 &nbsp;  |&nbsp; | Use `as_writable_bytes()`, subscript indexing |
 0.35.0  |   -   | `gsl_CONFIG_CONTRACT_LEVEL_ON`, `gsl_CONFIG_CONTRACT_LEVEL_OFF`, `gsl_CONFIG_CONTRACT_LEVEL_EXPECTS_ONLY` and `gsl_CONFIG_CONTRACT_LEVEL_ENSURES_ONLY` |

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Macro                                                                           
 ------------------------------------------------------------------------------------:|:---------------------------------------------------------|-------------------|-|
 [`gsl_FEATURE_OWNER_MACRO`](#gsl_feature_owner_macro1)                               | 1                                                        | 0                 | an unprefixed macro `Owner()` may interfere with user code |
 [`gsl_FEATURE_GSL_LITE_NAMESPACE`](#gsl_feature_gsl_lite_namespace0)                 | 0                                                        | 1                 | cf. [Using *gsl-lite* in libraries](#using-gsl-lite-in-libraries) |
-[`gsl_CONFIG_DEPRECATE_TO_LEVEL`](#gsl_config_deprecate_to_level0)                   | 0                                                        | 8                 | |
+[`gsl_CONFIG_DEPRECATE_TO_LEVEL`](#gsl_config_deprecate_to_level0)                   | 0                                                        | 7                 | |
 [`gsl_CONFIG_INDEX_TYPE`](#gsl_config_index_typegsl_config_span_index_type)          | `gsl_CONFIG_SPAN_INDEX_TYPE` (defaults to `std::size_t`) | `std::ptrdiff_t`  | the GSL specifies `gsl::index` to be a signed type, and M-GSL also uses `std::ptrdiff_t` |
 [`gsl_CONFIG_ALLOWS_SPAN_COMPARISON`](#gsl_config_allows_span_comparison1)           | 1                                                        | 0                 | C++20 `std::span<>` does not support comparison because semantics (deep vs. shallow) are unclear |
 [`gsl_CONFIG_NOT_NULL_EXPLICIT_CTOR`](#gsl_config_not_null_explicit_ctor0)           | 0                                                        | 1                 | cf. reasoning in [M-GSL/#395](https://github.com/Microsoft/GSL/issues/395) (note that `not_null<>` in M-GSL has an implicit constructor, cf. [M-GSL/#699](https://github.com/Microsoft/GSL/issues/699)) |
@@ -680,7 +680,7 @@ The following features are deprecated since the indicated version. See macro [`g
 
 Version | Level | Feature / Notes |
 -------:|:-----:|:----------------|
-0.41.0  |   7   | `string_span<>`, `zstring_span<>` and related types |
+0.41.0  |   7   | `basic_string_span<>`, `basic_zstring_span<>` and related aliases |
 0.37.0  |   6   | `as_writeable_bytes()`, call indexing for spans, and `span::at()` |
 &nbsp;  |&nbsp; | Use `as_writable_bytes()`, subscript indexing |
 0.35.0  |   -   | `gsl_CONFIG_CONTRACT_LEVEL_ON`, `gsl_CONFIG_CONTRACT_LEVEL_OFF`, `gsl_CONFIG_CONTRACT_LEVEL_EXPECTS_ONLY` and `gsl_CONFIG_CONTRACT_LEVEL_ENSURES_ONLY` |

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -5191,8 +5191,10 @@ namespace detail {
 template< class T, class SizeType, const T Sentinel >
 gsl_constexpr14 static span<T> ensure_sentinel( T * seq, SizeType max = (std::numeric_limits<SizeType>::max)() )
 {
+    typedef T * pointer;
+
     gsl_SUPPRESS_MSVC_WARNING( 26429, "f.23: symbol 'cur' is never tested for nullness, it can be marked as not_null" )
-    T * cur = seq;
+    pointer cur = seq;
 
     while ( static_cast<SizeType>( cur - seq ) < max && *cur != Sentinel )
         ++cur;
@@ -5201,7 +5203,6 @@ gsl_constexpr14 static span<T> ensure_sentinel( T * seq, SizeType max = (std::nu
 
     return span<T>( seq, gsl::narrow_cast< typename span<T>::index_type >( cur - seq ) );
 }
-
 } // namespace detail
 
 //
@@ -5212,7 +5213,7 @@ gsl_constexpr14 static span<T> ensure_sentinel( T * seq, SizeType max = (std::nu
 
 template< class T >
 gsl_NODISCARD inline gsl_constexpr14 span<T>
-ensure_z( T * sz, size_t max = (std::numeric_limits<size_t>::max)() )
+ensure_z( T * const & sz, size_t max = (std::numeric_limits<size_t>::max)() )
 {
     return detail::ensure_sentinel<T, size_t, 0>( sz, max );
 }

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -5191,10 +5191,8 @@ namespace detail {
 template< class T, class SizeType, const T Sentinel >
 gsl_constexpr14 static span<T> ensure_sentinel( T * seq, SizeType max = (std::numeric_limits<SizeType>::max)() )
 {
-    typedef T * pointer;
-
     gsl_SUPPRESS_MSVC_WARNING( 26429, "f.23: symbol 'cur' is never tested for nullness, it can be marked as not_null" )
-    pointer cur = seq;
+    T * cur = seq;
 
     while ( static_cast<SizeType>( cur - seq ) < max && *cur != Sentinel )
         ++cur;
@@ -5203,6 +5201,7 @@ gsl_constexpr14 static span<T> ensure_sentinel( T * seq, SizeType max = (std::nu
 
     return span<T>( seq, gsl::narrow_cast< typename span<T>::index_type >( cur - seq ) );
 }
+
 } // namespace detail
 
 //
@@ -5213,7 +5212,7 @@ gsl_constexpr14 static span<T> ensure_sentinel( T * seq, SizeType max = (std::nu
 
 template< class T >
 gsl_NODISCARD inline gsl_constexpr14 span<T>
-ensure_z( T * const & sz, size_t max = (std::numeric_limits<size_t>::max)() )
+ensure_z( T * sz, size_t max = (std::numeric_limits<size_t>::max)() )
 {
     return detail::ensure_sentinel<T, size_t, 0>( sz, max );
 }

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -183,6 +183,15 @@
 #endif
 #define gsl_FEATURE_OWNER_MACRO_()  gsl_FEATURE_OWNER_MACRO
 
+//#if defined( gsl_FEATURE_STRING_SPAN )
+//# if ! gsl_CHECK_CFG_TOGGLE_VALUE_( gsl_FEATURE_STRING_SPAN )
+//#  pragma message ("invalid configuration value gsl_FEATURE_STRING_SPAN=" gsl_STRINGIFY(gsl_FEATURE_STRING_SPAN) ", must be 0 or 1")
+//# endif
+//#else
+//# define gsl_FEATURE_STRING_SPAN  (gsl_CONFIG_DEFAULTS_VERSION == 0)  // default
+//#endif
+//#define gsl_FEATURE_STRING_SPAN_()  gsl_FEATURE_STRING_SPAN
+
 #if defined( gsl_FEATURE_EXPERIMENTAL_RETURN_GUARD )
 # if ! gsl_CHECK_CFG_TOGGLE_VALUE_( gsl_FEATURE_EXPERIMENTAL_RETURN_GUARD )
 #  pragma message ("invalid configuration value gsl_FEATURE_EXPERIMENTAL_RETURN_GUARD=" gsl_STRINGIFY(gsl_FEATURE_EXPERIMENTAL_RETURN_GUARD) ", must be 0 or 1")
@@ -217,7 +226,7 @@
 
 #if ! defined( gsl_CONFIG_DEPRECATE_TO_LEVEL )
 # if gsl_CONFIG_DEFAULTS_VERSION >= 1
-#  define gsl_CONFIG_DEPRECATE_TO_LEVEL  6
+#  define gsl_CONFIG_DEPRECATE_TO_LEVEL  8
 # else
 #  define gsl_CONFIG_DEPRECATE_TO_LEVEL  0
 # endif
@@ -4439,6 +4448,7 @@ byte_span( T const & t ) gsl_noexcept
 
 #endif // gsl_FEATURE_TO_STD( BYTE_SPAN )
 
+//#if gsl_FEATURE( STRING_SPAN )
 //
 // basic_string_span:
 //
@@ -4476,6 +4486,9 @@ gsl_api inline gsl_constexpr14 std::size_t string_length( T * ptr, std::size_t m
 // basic_string_span<> - A view of contiguous characters, replace (*,len).
 //
 template< class T >
+#if ! gsl_DEPRECATE_TO_LEVEL( 7 )
+gsl_DEPRECATED_MSG("use span<> instead")
+#endif // ! gsl_DEPRECATE_TO_LEVEL( 7 )
 class basic_string_span
 {
 public:
@@ -4979,6 +4992,7 @@ as_bytes( basic_string_span<T> spn ) gsl_noexcept
 {
     return span< const byte >( reinterpret_cast<const byte *>( spn.data() ), spn.size_bytes() ); // NOLINT
 }
+//#endif // gsl_FEATURE( STRING_SPAN )
 
 //
 // String types:
@@ -4991,6 +5005,8 @@ typedef const char * czstring;
 typedef wchar_t * wzstring;
 typedef const wchar_t * cwzstring;
 #endif
+
+//#if gsl_FEATURE( STRING_SPAN )
 
 typedef basic_string_span< char > string_span;
 typedef basic_string_span< char const > cstring_span;
@@ -5112,6 +5128,7 @@ std::basic_ostream< wchar_t, Traits > & operator<<( std::basic_ostream< wchar_t,
 }
 
 #endif // gsl_HAVE( WCHAR )
+//#endif // gsl_FEATURE( STRING_SPAN )
 
 //
 // ensure_sentinel()
@@ -5170,11 +5187,15 @@ ensure_z( Container & cont )
 }
 # endif
 
+//#if gsl_FEATURE( STRING_SPAN )
 //
 // basic_zstring_span<> - A view of contiguous null-terminated characters, replace (*,len).
 //
 
 template <typename T>
+#if ! gsl_DEPRECATE_TO_LEVEL( 7 )
+gsl_DEPRECATED
+#endif // ! gsl_DEPRECATE_TO_LEVEL( 7 )
 class basic_zstring_span
 {
 public:
@@ -5244,6 +5265,7 @@ typedef basic_zstring_span< char const > czstring_span;
 typedef basic_zstring_span< wchar_t > wzstring_span;
 typedef basic_zstring_span< wchar_t const > cwzstring_span;
 #endif
+//#endif // gsl_FEATURE( STRING_SPAN )
 
 } // namespace gsl
 
@@ -5428,6 +5450,7 @@ using ::gsl::as_writable_bytes;
 using ::gsl::as_writeable_bytes;
 # endif
 
+//# if gsl_FEATURE( STRING_SPAN )
 using ::gsl::basic_string_span;
 using ::gsl::string_span;
 using ::gsl::cstring_span;
@@ -5435,6 +5458,7 @@ using ::gsl::cstring_span;
 using ::gsl::basic_zstring_span;
 using ::gsl::zstring_span;
 using ::gsl::czstring_span;
+//# endif // gsl_FEATURE( STRING_SPAN )
 
 using ::gsl::zstring;
 using ::gsl::czstring;
@@ -5443,8 +5467,10 @@ using ::gsl::czstring;
 using ::gsl::wzstring;
 using ::gsl::cwzstring;
 
+//#  if gsl_FEATURE( STRING_SPAN )
 using ::gsl::wzstring_span;
 using ::gsl::cwzstring_span;
+//#  endif // gsl_FEATURE( STRING_SPAN )
 # endif // gsl_HAVE( WCHAR )
 
 using ::gsl::ensure_z;

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -4486,10 +4486,11 @@ gsl_api inline gsl_constexpr14 std::size_t string_length( T * ptr, std::size_t m
 // basic_string_span<> - A view of contiguous characters, replace (*,len).
 //
 template< class T >
+class
 #if gsl_DEPRECATE_TO_LEVEL( 7 )
 gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
 #endif // gsl_DEPRECATE_TO_LEVEL( 7 )
-class basic_string_span
+basic_string_span
 {
 public:
     typedef T element_type;
@@ -4524,30 +4525,18 @@ public:
 #ifdef __CUDACC_RELAXED_CONSTEXPR__
     gsl_api
 #endif // __CUDACC_RELAXED_CONSTEXPR__
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_constexpr basic_string_span( pointer ptr )
     : span_( remove_z( ptr, (std::numeric_limits<index_type>::max)() ) )
     {}
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_api gsl_constexpr basic_string_span( pointer ptr, index_type count )
     : span_( ptr, count )
     {}
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_api gsl_constexpr basic_string_span( pointer firstElem, pointer lastElem )
     : span_( firstElem, lastElem )
     {}
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< std::size_t N >
     gsl_constexpr basic_string_span( element_type (&arr)[N] )
     : span_( remove_z( gsl_ADDRESSOF( arr[0] ), N ) )
@@ -4555,17 +4544,11 @@ public:
 
 #if gsl_HAVE( ARRAY )
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< std::size_t N >
     gsl_constexpr basic_string_span( std::array< typename std11::remove_const<element_type>::type, N> & arr )
     : span_( remove_z( arr ) )
     {}
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< std::size_t N >
     gsl_constexpr basic_string_span( std::array< typename std11::remove_const<element_type>::type, N> const & arr )
     : span_( remove_z( arr ) )
@@ -4577,9 +4560,6 @@ public:
 
     // Exclude: array, [basic_string,] basic_string_span
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class Container
         gsl_ENABLE_IF_((
             ! detail::is_std_array< Container >::value
@@ -4594,9 +4574,6 @@ public:
 
     // Exclude: array, [basic_string,] basic_string_span
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class Container
         gsl_ENABLE_IF_((
             ! detail::is_std_array< Container >::value
@@ -4611,17 +4588,11 @@ public:
 
 #elif gsl_HAVE( UNCONSTRAINED_SPAN_CONTAINER_CTOR )
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class Container >
     gsl_constexpr basic_string_span( Container & cont )
     : span_( cont )
     {}
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class Container >
     gsl_constexpr basic_string_span( Container const & cont )
     : span_( cont )
@@ -4629,9 +4600,6 @@ public:
 
 #else
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class U >
     gsl_api gsl_constexpr basic_string_span( span<U> const & rhs )
     : span_( rhs )
@@ -4641,9 +4609,6 @@ public:
 
 #if gsl_FEATURE_TO_STD( WITH_CONTAINER )
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class Container >
     gsl_constexpr basic_string_span( with_container_t, Container & cont )
     : span_( with_container, cont )
@@ -4662,9 +4627,6 @@ public:
 # endif
 #endif
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class U
         gsl_ENABLE_IF_(( std::is_convertible<typename basic_string_span<U>::pointer, pointer>::value ))
     >
@@ -4673,9 +4635,6 @@ public:
     {}
 
 #if gsl_STDLIB_CPP11_120
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class U
         gsl_ENABLE_IF_(( std::is_convertible<typename basic_string_span<U>::pointer, pointer>::value ))
     >
@@ -4684,18 +4643,12 @@ public:
     {}
 #endif // gsl_STDLIB_CPP11_120
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class CharTraits, class Allocator >
     gsl_constexpr basic_string_span(
         std::basic_string< typename std11::remove_const<element_type>::type, CharTraits, Allocator > & str )
     : span_( gsl_ADDRESSOF( str[0] ), str.length() )
     {}
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class CharTraits, class Allocator >
     gsl_constexpr basic_string_span(
         std::basic_string< typename std11::remove_const<element_type>::type, CharTraits, Allocator > const & str )
@@ -5241,10 +5194,11 @@ ensure_z( Container & cont )
 //
 
 template <typename T>
+class
 #if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_zstring_span<> is deprecated")
+gsl_DEPRECATED_MSG("basic_zstring_span<> is deprecated")
 #endif // gsl_DEPRECATE_TO_LEVEL( 7 )
-class basic_zstring_span
+basic_zstring_span
 {
 public:
     typedef T element_type;
@@ -5256,9 +5210,6 @@ public:
     typedef element_type * czstring_type;
     typedef basic_string_span<element_type> string_span_type;
 
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-    gsl_DEPRECATED_MSG("basic_zstring_span<> is deprecated")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_api gsl_constexpr14 basic_zstring_span( span_type s )
         : span_( s )
     {

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -4486,11 +4486,7 @@ gsl_api inline gsl_constexpr14 std::size_t string_length( T * ptr, std::size_t m
 // basic_string_span<> - A view of contiguous characters, replace (*,len).
 //
 template< class T >
-class
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
-basic_string_span
+class basic_string_span
 {
 public:
     typedef T element_type;
@@ -4525,19 +4521,31 @@ public:
 #ifdef __CUDACC_RELAXED_CONSTEXPR__
     gsl_api
 #endif // __CUDACC_RELAXED_CONSTEXPR__
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_constexpr basic_string_span( pointer ptr )
     : span_( remove_z( ptr, (std::numeric_limits<index_type>::max)() ) )
     {}
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_api gsl_constexpr basic_string_span( pointer ptr, index_type count )
     : span_( ptr, count )
     {}
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_api gsl_constexpr basic_string_span( pointer firstElem, pointer lastElem )
     : span_( firstElem, lastElem )
     {}
 
     template< std::size_t N >
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_constexpr basic_string_span( element_type (&arr)[N] )
     : span_( remove_z( gsl_ADDRESSOF( arr[0] ), N ) )
     {}
@@ -4545,11 +4553,17 @@ public:
 #if gsl_HAVE( ARRAY )
 
     template< std::size_t N >
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_constexpr basic_string_span( std::array< typename std11::remove_const<element_type>::type, N> & arr )
     : span_( remove_z( arr ) )
     {}
 
     template< std::size_t N >
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_constexpr basic_string_span( std::array< typename std11::remove_const<element_type>::type, N> const & arr )
     : span_( remove_z( arr ) )
     {}
@@ -4568,6 +4582,9 @@ public:
             && std::is_convertible< typename Container::pointer, decltype(std::declval<Container>().data()) >::value
         ))
     >
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_constexpr basic_string_span( Container & cont )
     : span_( ( cont ) )
     {}
@@ -4582,6 +4599,9 @@ public:
             && std::is_convertible< typename Container::pointer, decltype(std::declval<Container const &>().data()) >::value
         ))
     >
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_constexpr basic_string_span( Container const & cont )
     : span_( ( cont ) )
     {}
@@ -4589,11 +4609,17 @@ public:
 #elif gsl_HAVE( UNCONSTRAINED_SPAN_CONTAINER_CTOR )
 
     template< class Container >
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_constexpr basic_string_span( Container & cont )
     : span_( cont )
     {}
 
     template< class Container >
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_constexpr basic_string_span( Container const & cont )
     : span_( cont )
     {}
@@ -4601,6 +4627,9 @@ public:
 #else
 
     template< class U >
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_api gsl_constexpr basic_string_span( span<U> const & rhs )
     : span_( rhs )
     {}
@@ -4610,6 +4639,9 @@ public:
 #if gsl_FEATURE_TO_STD( WITH_CONTAINER )
 
     template< class Container >
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_constexpr basic_string_span( with_container_t, Container & cont )
     : span_( with_container, cont )
     {}
@@ -4630,6 +4662,9 @@ public:
     template< class U
         gsl_ENABLE_IF_(( std::is_convertible<typename basic_string_span<U>::pointer, pointer>::value ))
     >
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_api gsl_constexpr basic_string_span( basic_string_span<U> const & rhs )
     : span_( reinterpret_cast<pointer>( rhs.data() ), rhs.length() ) // NOLINT
     {}
@@ -4638,18 +4673,27 @@ public:
     template< class U
         gsl_ENABLE_IF_(( std::is_convertible<typename basic_string_span<U>::pointer, pointer>::value ))
     >
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_api gsl_constexpr basic_string_span( basic_string_span<U> && rhs )
     : span_( reinterpret_cast<pointer>( rhs.data() ), rhs.length() ) // NOLINT
     {}
 #endif // gsl_STDLIB_CPP11_120
 
     template< class CharTraits, class Allocator >
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_constexpr basic_string_span(
         std::basic_string< typename std11::remove_const<element_type>::type, CharTraits, Allocator > & str )
     : span_( gsl_ADDRESSOF( str[0] ), str.length() )
     {}
 
     template< class CharTraits, class Allocator >
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_constexpr basic_string_span(
         std::basic_string< typename std11::remove_const<element_type>::type, CharTraits, Allocator > const & str )
     : span_( gsl_ADDRESSOF( str[0] ), str.length() )
@@ -5194,11 +5238,7 @@ ensure_z( Container & cont )
 //
 
 template <typename T>
-class
-#if gsl_DEPRECATE_TO_LEVEL( 7 )
-gsl_DEPRECATED_MSG("basic_zstring_span<> is deprecated")
-#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
-basic_zstring_span
+class basic_zstring_span
 {
 public:
     typedef T element_type;
@@ -5210,6 +5250,9 @@ public:
     typedef element_type * czstring_type;
     typedef basic_string_span<element_type> string_span_type;
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_zstring_span<> is deprecated")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_api gsl_constexpr14 basic_zstring_span( span_type s )
         : span_( s )
     {
@@ -5233,13 +5276,19 @@ public:
         return false;
     }
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_zstring_span<> is deprecated")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_NODISCARD gsl_api gsl_constexpr string_span_type
     as_string_span() const gsl_noexcept
     {
         return string_span_type( span_.data(), span_.size() - 1 );
     }
 
-    /*gsl_api*/ // currently disabled due to an apparent NVCC bug
+ #if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_zstring_span<> is deprecated")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
+   /*gsl_api*/ // currently disabled due to an apparent NVCC bug
     gsl_NODISCARD gsl_constexpr string_span_type
     ensure_z() const
     {

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -226,7 +226,7 @@
 
 #if ! defined( gsl_CONFIG_DEPRECATE_TO_LEVEL )
 # if gsl_CONFIG_DEFAULTS_VERSION >= 1
-#  define gsl_CONFIG_DEPRECATE_TO_LEVEL  8
+#  define gsl_CONFIG_DEPRECATE_TO_LEVEL  7
 # else
 #  define gsl_CONFIG_DEPRECATE_TO_LEVEL  0
 # endif
@@ -4486,9 +4486,9 @@ gsl_api inline gsl_constexpr14 std::size_t string_length( T * ptr, std::size_t m
 // basic_string_span<> - A view of contiguous characters, replace (*,len).
 //
 template< class T >
-#if ! gsl_DEPRECATE_TO_LEVEL( 7 )
-gsl_DEPRECATED_MSG("use span<> instead")
-#endif // ! gsl_DEPRECATE_TO_LEVEL( 7 )
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
 class basic_string_span
 {
 public:
@@ -4524,18 +4524,30 @@ public:
 #ifdef __CUDACC_RELAXED_CONSTEXPR__
     gsl_api
 #endif // __CUDACC_RELAXED_CONSTEXPR__
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_constexpr basic_string_span( pointer ptr )
     : span_( remove_z( ptr, (std::numeric_limits<index_type>::max)() ) )
     {}
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_api gsl_constexpr basic_string_span( pointer ptr, index_type count )
     : span_( ptr, count )
     {}
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_api gsl_constexpr basic_string_span( pointer firstElem, pointer lastElem )
     : span_( firstElem, lastElem )
     {}
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< std::size_t N >
     gsl_constexpr basic_string_span( element_type (&arr)[N] )
     : span_( remove_z( gsl_ADDRESSOF( arr[0] ), N ) )
@@ -4543,11 +4555,17 @@ public:
 
 #if gsl_HAVE( ARRAY )
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< std::size_t N >
     gsl_constexpr basic_string_span( std::array< typename std11::remove_const<element_type>::type, N> & arr )
     : span_( remove_z( arr ) )
     {}
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< std::size_t N >
     gsl_constexpr basic_string_span( std::array< typename std11::remove_const<element_type>::type, N> const & arr )
     : span_( remove_z( arr ) )
@@ -4559,6 +4577,9 @@ public:
 
     // Exclude: array, [basic_string,] basic_string_span
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class Container
         gsl_ENABLE_IF_((
             ! detail::is_std_array< Container >::value
@@ -4573,6 +4594,9 @@ public:
 
     // Exclude: array, [basic_string,] basic_string_span
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class Container
         gsl_ENABLE_IF_((
             ! detail::is_std_array< Container >::value
@@ -4587,11 +4611,17 @@ public:
 
 #elif gsl_HAVE( UNCONSTRAINED_SPAN_CONTAINER_CTOR )
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class Container >
     gsl_constexpr basic_string_span( Container & cont )
     : span_( cont )
     {}
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class Container >
     gsl_constexpr basic_string_span( Container const & cont )
     : span_( cont )
@@ -4599,6 +4629,9 @@ public:
 
 #else
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class U >
     gsl_api gsl_constexpr basic_string_span( span<U> const & rhs )
     : span_( rhs )
@@ -4608,6 +4641,9 @@ public:
 
 #if gsl_FEATURE_TO_STD( WITH_CONTAINER )
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class Container >
     gsl_constexpr basic_string_span( with_container_t, Container & cont )
     : span_( with_container, cont )
@@ -4626,6 +4662,9 @@ public:
 # endif
 #endif
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class U
         gsl_ENABLE_IF_(( std::is_convertible<typename basic_string_span<U>::pointer, pointer>::value ))
     >
@@ -4634,6 +4673,9 @@ public:
     {}
 
 #if gsl_STDLIB_CPP11_120
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class U
         gsl_ENABLE_IF_(( std::is_convertible<typename basic_string_span<U>::pointer, pointer>::value ))
     >
@@ -4642,12 +4684,18 @@ public:
     {}
 #endif // gsl_STDLIB_CPP11_120
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class CharTraits, class Allocator >
     gsl_constexpr basic_string_span(
         std::basic_string< typename std11::remove_const<element_type>::type, CharTraits, Allocator > & str )
     : span_( gsl_ADDRESSOF( str[0] ), str.length() )
     {}
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_string_span<><> is deprecated; use span<> instead")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     template< class CharTraits, class Allocator >
     gsl_constexpr basic_string_span(
         std::basic_string< typename std11::remove_const<element_type>::type, CharTraits, Allocator > const & str )
@@ -5193,9 +5241,9 @@ ensure_z( Container & cont )
 //
 
 template <typename T>
-#if ! gsl_DEPRECATE_TO_LEVEL( 7 )
-gsl_DEPRECATED
-#endif // ! gsl_DEPRECATE_TO_LEVEL( 7 )
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_zstring_span<> is deprecated")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
 class basic_zstring_span
 {
 public:
@@ -5208,6 +5256,9 @@ public:
     typedef element_type * czstring_type;
     typedef basic_string_span<element_type> string_span_type;
 
+#if gsl_DEPRECATE_TO_LEVEL( 7 )
+    gsl_DEPRECATED_MSG("basic_zstring_span<> is deprecated")
+#endif // gsl_DEPRECATE_TO_LEVEL( 7 )
     gsl_api gsl_constexpr14 basic_zstring_span( span_type s )
         : span_( s )
     {


### PR DESCRIPTION
"Removal" meaning "hiding behind feature flag" because we don't actually remove anything at all if we can help it.

For `string_span` removal, see #6; for `zstring_span` removal, see #282.