### PR TITLE
Cast char to signed to avoid type-limits warning

### DIFF
--- a/test/lest_cpp03.hpp
+++ b/test/lest_cpp03.hpp
@@ -704,7 +704,7 @@ inline void inform( location where, text expr )
 
 // Expression decomposition:
 
-inline bool unprintable( char c ) { return 0 <= c && c < ' '; }
+inline bool unprintable( char c ) { return 0 <= static_cast<signed char>(c) && c < ' '; }
 
 inline std::string to_hex_string(char c)
 {

--- a/test/lest_cpp03.hpp
+++ b/test/lest_cpp03.hpp
@@ -704,7 +704,7 @@ inline void inform( location where, text expr )
 
 // Expression decomposition:
 
-inline bool unprintable( char c ) { return 0 <= static_cast<signed char>(c) && c < ' '; }
+inline bool unprintable( char c ) { return 0 <= static_cast<signed char>(c) && c < ' '; }  // the cast is necessary on architectures where char is unsigned
 
 inline std::string to_hex_string(char c)
 {


### PR DESCRIPTION
On at least GCC 13, on platforms where `char` is unsigned by default, checking if a `char`’s value is nonnegative by comparing to integer zero produced a warning which was treated as an error: “`comparison is always true due to limited range of data type [-Werror=type-limits]`”

Fixes #337.