### PR TITLE
Improve `finally()`, `on_return()`, and `on_error()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Macro                                                                           
 ------------------------------------------------------------------------------------:|:---------------------------------------------------------|-------------------|-|
 [`gsl_FEATURE_OWNER_MACRO`](#gsl_feature_owner_macro1)                               | 1                                                        | 0                 | an unprefixed macro `Owner()` may interfere with user code |
 [`gsl_FEATURE_GSL_LITE_NAMESPACE`](#gsl_feature_gsl_lite_namespace0)                 | 0                                                        | 1                 | cf. [Using *gsl-lite* in libraries](#using-gsl-lite-in-libraries) |
-[`gsl_CONFIG_DEPRECATE_TO_LEVEL`](#gsl_config_deprecate_to_level0)                   | 0                                                        | 7                 | |
+[`gsl_CONFIG_DEPRECATE_TO_LEVEL`](#gsl_config_deprecate_to_level0)                   | 0                                                        | 8                 | |
 [`gsl_CONFIG_INDEX_TYPE`](#gsl_config_index_typegsl_config_span_index_type)          | `gsl_CONFIG_SPAN_INDEX_TYPE` (defaults to `std::size_t`) | `std::ptrdiff_t`  | the GSL specifies `gsl::index` to be a signed type, and M-GSL also uses `std::ptrdiff_t` |
 [`gsl_CONFIG_ALLOWS_SPAN_COMPARISON`](#gsl_config_allows_span_comparison1)           | 1                                                        | 0                 | C++20 `std::span<>` does not support comparison because semantics (deep vs. shallow) are unclear |
 [`gsl_CONFIG_NOT_NULL_EXPLICIT_CTOR`](#gsl_config_not_null_explicit_ctor0)           | 0                                                        | 1                 | cf. reasoning in [M-GSL/#395](https://github.com/Microsoft/GSL/issues/395) (note that `not_null<>` in M-GSL has an implicit constructor, cf. [M-GSL/#699](https://github.com/Microsoft/GSL/issues/699)) |
@@ -615,11 +615,6 @@ Feature / library           | GSL     | M-GSL   | *gsl-lite* | Notes |
 `byte_span()`               | -       | -       | ✓         | Create a span of bytes from a single object |
 `as_bytes()`                | -       | ✓      | ✓         | A span as bytes |
 `as_writable_bytes`         | -       | ✓      | ✓         | A span as writable bytes |
-`basic_string_span<>`       | -       | ✓      | ✓         | See also proposal [p0123](http://wg21.link/p0123) |
-`string_span`               | ✓      | ✓      | ✓         | `basic_string_span< char >` |
-`wstring_span`              | -       | ✓      | ✓         | `basic_string_span< wchar_t >` |
-`cstring_span`              | ✓      | ✓      | ✓         | `basic_string_span< const char >` |
-`cwstring_span`             | -       | ✓      | ✓         | `basic_string_span< const wchar_t >` |
 `zstring_span`              | -       | ✓      | ✓         | `basic_zstring_span< char >` |
 `wzstring_span`             | -       | ✓      | ✓         | `basic_zstring_span< wchar_t >` |
 `czstring_span`             | -       | ✓      | ✓         | `basic_zstring_span< const char >` |
@@ -649,15 +644,9 @@ Feature / library           | GSL     | M-GSL   | *gsl-lite* | Notes |
 `diff`                      | -      | -      | ✓        | type for index differences |
 `byte`                      | -       | ✓      | ✓         | byte type, see also proposal [p0298](http://wg21.link/p0298) |
 `final_action<>`            | ✓      | ✓      | ≥&nbsp;C++11    | Action at the end of a scope |
-`final_action`              | -       | -       | <&nbsp;C++11    | Currently only `void(*)()` |
 `finally()`                 | ✓      | ✓      | ≥&nbsp;C++11    | Make a `final_action<>` |
-`finally()`                 | -       | -       | <&nbsp;C++11    | Make a `final_action` |
-`final_action_return`       | -       | -       | <&nbsp;C++11    | Currently only `void(*)()`, [experimental](#feature-selection-macros) |
 `on_return()`               | -       | -       | ≥&nbsp;C++11    | Make a `final_action_return<>, [experimental](#feature-selection-macros) |
-`on_return()`               | -       | -       | <&nbsp;C++11    | Make a `final_action_return, [experimental](#feature-selection-macros) |
-`final_action_error`        | -       | -       | <&nbsp;C++11    | Currently only `void(*)()`, [experimental](#feature-selection-macros) |
 `on_error()`                | -       | -       | ≥&nbsp;C++11    | Make a `final_action_error<>`, [experimental](#feature-selection-macros) |
-`on_error()`                | -       | -       | <&nbsp;C++11    | Make a `final_action_error`, [experimental](#feature-selection-macros) |
 `narrow_cast<>`             | ✓      | ✓      | ✓         | Searchable narrowing casts of values |
 `narrow<>()`                | ✓      | ✓      | ✓         | Checked narrowing cast |
 `narrow_failfast<>()`       | -       | -       | ✓         | Fail-fast narrowing cast |
@@ -680,6 +669,7 @@ The following features are deprecated since the indicated version. See macro [`g
 
 Version | Level | Feature / Notes |
 -------:|:-----:|:----------------|
+0.42.0  |   8   | `finally()`, `on_return()`, and `on_error()` for pre-C++11        |
 0.41.0  |   7   | `basic_string_span<>`, `basic_zstring_span<>` and related aliases |
 0.37.0  |   6   | `as_writeable_bytes()`, call indexing for spans, and `span::at()` |
 &nbsp;  |&nbsp; | Use `as_writable_bytes()`, subscript indexing |
@@ -1215,7 +1205,6 @@ operator<<: Allows printing a cwstring_span to an output stream
 finally: Allows to run lambda on leaving scope
 finally: Allows to run function (bind) on leaving scope
 finally: Allows to run function (pointer) on leaving scope
-finally: Allows to move final_action
 on_return: Allows to perform action on leaving scope without exception (gsl_FEATURE_EXPERIMENTAL_RETURN_GUARD)
 on_error: Allows to perform action on leaving scope via an exception (gsl_FEATURE_EXPERIMENTAL_RETURN_GUARD)
 narrow_cast<>: Allows narrowing without value loss

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -2092,21 +2092,30 @@ class final_action
 public:
     explicit final_action( F action ) gsl_noexcept
         : action_( std::move( action ) )
-        , invoke_( true )
-    {}
-
-    final_action( final_action && other ) gsl_noexcept
-        : action_( std::move( other.action_ ) )
-        , invoke_( other.invoke_ )
     {
-        other.invoke_ = false;
     }
 
-    gsl_SUPPRESS_MSGSL_WARNING(f.6)
-    virtual ~final_action() gsl_noexcept
+        // We only provide the move constructor for legacy defaults, or if we cannot rely on C++17 guaranteed copy elision.
+#if gsl_CONFIG_DEFAULTS_VERSION < 1 || ! gsl_CPP17_OR_GREATER
+    final_action( final_action && other ) gsl_noexcept
+        : action_( std::move( other.action_ ) )
+        , invoke_( std::exchange( other.invoke_, false ) )
     {
+    }
+#endif // gsl_CONFIG_DEFAULTS_VERSION < 1 || ! gsl_CPP17_OR_GREATER
+
+    gsl_SUPPRESS_MSGSL_WARNING(f.6)
+#if gsl_CONFIG_DEFAULTS_VERSION < 1  // we avoid the unnecessary virtual calls if modern defaults are selected
+    virtual
+#endif
+    ~final_action() gsl_noexcept
+    {
+#if gsl_CONFIG_DEFAULTS_VERSION < 1 || ! gsl_CPP17_OR_GREATER
         if ( invoke_ )
+#endif
+        {
             action_();
+        }
     }
 
 gsl_is_delete_access:
@@ -2114,33 +2123,124 @@ gsl_is_delete_access:
     final_action & operator=( final_action const & ) gsl_is_delete;
     final_action & operator=( final_action && ) gsl_is_delete;
 
+#if gsl_CONFIG_DEFAULTS_VERSION < 1
 protected:
     void dismiss() gsl_noexcept
     {
         invoke_ = false;
     }
+#endif // gsl_CONFIG_DEFAULTS_VERSION < 1
 
 private:
     F action_;
-    bool invoke_;
+#if gsl_CONFIG_DEFAULTS_VERSION < 1 || ! gsl_CPP17_OR_GREATER
+    bool invoke_ = true;
+#endif
 };
 
 template< class F >
-gsl_NODISCARD inline final_action<F>
-finally( F const & action ) gsl_noexcept
-{
-    return final_action<F>( action );
-}
-
-template< class F >
-gsl_NODISCARD inline final_action<F>
+gsl_NODISCARD inline final_action<typename std::decay<F>::type>
 finally( F && action ) gsl_noexcept
 {
-    return final_action<F>( std::forward<F>( action ) );
+    return final_action<typename std::decay<F>::type>( std::forward<F>( action ) );
 }
 
 # if gsl_FEATURE( EXPERIMENTAL_RETURN_GUARD )
 
+#if gsl_CONFIG_DEFAULTS_VERSION >= 1
+template< class F >
+class final_action_return
+{
+public:
+    explicit final_action_return( F action ) gsl_noexcept
+        : action_( std::move( action ) )
+        , exception_count_( std11::uncaught_exceptions() )
+    {
+    }
+
+        // We only provide the move constructor if we cannot rely on C++17 guaranteed copy elision.
+#if ! gsl_CPP17_OR_GREATER
+    final_action_return( final_action_return && other ) gsl_noexcept
+        : action_( std::move( other.action_ ) )
+        , exception_count_( other.exception_count_ )
+        , invoke_( std::exchange( other.invoke_, false ) )
+    {
+    }
+#endif // ! gsl_CPP17_OR_GREATER
+
+    gsl_SUPPRESS_MSGSL_WARNING(f.6)
+    ~final_action_return() gsl_noexcept
+    {
+#if ! gsl_CPP17_OR_GREATER
+        if ( invoke_ )
+#endif
+        {
+            if ( std11::uncaught_exceptions() == exception_count_ )
+            {
+                action_();
+            }
+        }
+    }
+
+gsl_is_delete_access:
+    final_action_return( final_action_return const & ) gsl_is_delete;
+    final_action_return & operator=( final_action_return const & ) gsl_is_delete;
+    final_action_return & operator=( final_action_return && ) gsl_is_delete;
+
+private:
+    F action_;
+    unsigned char exception_count_;
+#if ! gsl_CPP17_OR_GREATER
+    bool invoke_ = true;
+#endif
+};
+template< class F >
+class final_action_error
+{
+public:
+    explicit final_action_error( F action ) gsl_noexcept
+        : action_( std::move( action ) )
+        , exception_count_( std11::uncaught_exceptions() )
+    {
+    }
+
+        // We only provide the move constructor if we cannot rely on C++17 guaranteed copy elision.
+#if ! gsl_CPP17_OR_GREATER
+    final_action_error( final_action_error && other ) gsl_noexcept
+        : action_( std::move( other.action_ ) )
+        , exception_count_( other.exception_count_ )
+        , invoke_( std::exchange( other.invoke_, false ) )
+    {
+    }
+#endif // ! gsl_CPP17_OR_GREATER
+
+    gsl_SUPPRESS_MSGSL_WARNING(f.6)
+    ~final_action_error() gsl_noexcept
+    {
+#if ! gsl_CPP17_OR_GREATER
+        if ( invoke_ )
+#endif
+        {
+            if ( std11::uncaught_exceptions() != exception_count_ )
+            {
+                action_();
+            }
+        }
+    }
+
+gsl_is_delete_access:
+    final_action_error( final_action_error const & ) gsl_is_delete;
+    final_action_error & operator=( final_action_error const & ) gsl_is_delete;
+    final_action_error & operator=( final_action_error && ) gsl_is_delete;
+
+private:
+    F action_;
+    unsigned char exception_count_;
+#if ! gsl_CPP17_OR_GREATER
+    bool invoke_ = true;
+#endif
+};
+#else // gsl_CONFIG_DEFAULTS_VERSION < 1
 template< class F >
 class final_action_return : public final_action<F>
 {
@@ -2170,20 +2270,6 @@ private:
 };
 
 template< class F >
-gsl_NODISCARD inline final_action_return<F>
-on_return( F const & action ) gsl_noexcept
-{
-    return final_action_return<F>( action );
-}
-
-template< class F >
-gsl_NODISCARD inline final_action_return<F>
-on_return( F && action ) gsl_noexcept
-{
-    return final_action_return<F>( std::forward<F>( action ) );
-}
-
-template< class F >
 class final_action_error : public final_action<F>
 {
 public:
@@ -2210,19 +2296,20 @@ gsl_is_delete_access:
 private:
     unsigned char exception_count;
 };
+#endif // gsl_CONFIG_DEFAULTS_VERSION >= 1
 
 template< class F >
-gsl_NODISCARD inline final_action_error<F>
-on_error( F const & action ) gsl_noexcept
+gsl_NODISCARD inline final_action_return<typename std::decay<F>::type>
+on_return( F && action ) gsl_noexcept
 {
-    return final_action_error<F>( action );
+    return final_action_return<typename std::decay<F>::type>( std::forward<F>( action ) );
 }
 
 template< class F >
-gsl_NODISCARD inline final_action_error<F>
+gsl_NODISCARD inline final_action_error<typename std::decay<F>::type>
 on_error( F && action ) gsl_noexcept
 {
-    return final_action_error<F>( std::forward<F>( action ) );
+    return final_action_error<typename std::decay<F>::type>( std::forward<F>( action ) );
 }
 
 # endif // gsl_FEATURE( EXPERIMENTAL_RETURN_GUARD )
@@ -2231,6 +2318,9 @@ gsl_RESTORE_MSVC_WARNINGS()
 
 #else // ! gsl_STDLIB_CPP11_110
 
+# if gsl_DEPRECATE_TO_LEVEL( 8 )
+gsl_DEPRECATED_MSG("final_action for pre-C++11 compilers is deprecated")
+# endif // gsl_DEPRECATE_TO_LEVEL( 8 )
 class final_action
 {
 public:
@@ -2269,13 +2359,19 @@ private:
 };
 
 template< class F >
+# if gsl_DEPRECATE_TO_LEVEL( 8 )
+gsl_DEPRECATED_MSG("finally() for pre-C++11 compilers is deprecated")
+# endif // gsl_DEPRECATE_TO_LEVEL( 8 )
 inline final_action finally( F const & f )
 {
-    return final_action(( f ));
+    return final_action( f );
 }
 
-#if gsl_FEATURE( EXPERIMENTAL_RETURN_GUARD )
+# if gsl_FEATURE( EXPERIMENTAL_RETURN_GUARD )
 
+#  if gsl_DEPRECATE_TO_LEVEL( 8 )
+gsl_DEPRECATED_MSG("final_action_return for pre-C++11 compilers is deprecated")
+#  endif // gsl_DEPRECATE_TO_LEVEL( 8 )
 class final_action_return : public final_action
 {
 public:
@@ -2298,11 +2394,17 @@ private:
 };
 
 template< class F >
+#  if gsl_DEPRECATE_TO_LEVEL( 8 )
+gsl_DEPRECATED_MSG("on_return() for pre-C++11 compilers is deprecated")
+#  endif // gsl_DEPRECATE_TO_LEVEL( 8 )
 inline final_action_return on_return( F const & action )
 {
     return final_action_return( action );
 }
 
+#  if gsl_DEPRECATE_TO_LEVEL( 8 )
+gsl_DEPRECATED_MSG("final_action_error for pre-C++11 compilers is deprecated")
+#  endif // gsl_DEPRECATE_TO_LEVEL( 8 )
 class final_action_error : public final_action
 {
 public:
@@ -2325,6 +2427,9 @@ private:
 };
 
 template< class F >
+#  if gsl_DEPRECATE_TO_LEVEL( 8 )
+gsl_DEPRECATED_MSG("on_error() for pre-C++11 compilers is deprecated")
+#  endif // gsl_DEPRECATE_TO_LEVEL( 8 )
 inline final_action_error on_error( F const & action )
 {
     return final_action_error( action );
@@ -2615,8 +2720,6 @@ gsl_is_delete_access:
     not_null_data( not_null_data const & ) gsl_is_delete;
     not_null_data & operator=( not_null_data const & ) gsl_is_delete;
 };
-# if gsl_CONFIG_DEFAULTS_VERSION >= 1
-# endif // gsl_CONFIG_DEFAULTS_VERSION >= 1
 #endif // gsl_HAVE( MOVE_FORWARD )
 template< class T >
 struct not_null_data< T, true >

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -2107,8 +2107,9 @@ public:
 #if gsl_CONFIG_DEFAULTS_VERSION < 1 || ! gsl_CPP17_OR_GREATER
     final_action( final_action && other ) gsl_noexcept
         : action_( std::move( other.action_ ) )
-        , invoke_( std::exchange( other.invoke_, false ) )
+        , invoke_( other.invoke_ )
     {
+        other.invoke_ = false;
     }
 #endif // gsl_CONFIG_DEFAULTS_VERSION < 1 || ! gsl_CPP17_OR_GREATER
 
@@ -2171,8 +2172,9 @@ public:
     final_action_return( final_action_return && other ) gsl_noexcept
         : action_( std::move( other.action_ ) )
         , exception_count_( other.exception_count_ )
-        , invoke_( std::exchange( other.invoke_, false ) )
+        , invoke_( other.invoke_ )
     {
+        other.invoke_ = false;
     }
 #endif // ! gsl_CPP17_OR_GREATER
 
@@ -2217,8 +2219,9 @@ public:
     final_action_error( final_action_error && other ) gsl_noexcept
         : action_( std::move( other.action_ ) )
         , exception_count_( other.exception_count_ )
-        , invoke_( std::exchange( other.invoke_, false ) )
+        , invoke_( other.invoke_ )
     {
+        other.invoke_ = false;
     }
 #endif // ! gsl_CPP17_OR_GREATER
 

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -2100,6 +2100,9 @@ class final_action
 public:
     explicit final_action( F action ) gsl_noexcept
         : action_( std::move( action ) )
+#if gsl_CONFIG_DEFAULTS_VERSION < 1 || ! gsl_CPP17_OR_GREATER
+        , invoke_( true )
+#endif
     {
     }
 
@@ -2143,7 +2146,7 @@ protected:
 private:
     F action_;
 #if gsl_CONFIG_DEFAULTS_VERSION < 1 || ! gsl_CPP17_OR_GREATER
-    bool invoke_ = true;
+    bool invoke_;
 #endif
 };
 
@@ -2164,6 +2167,9 @@ public:
     explicit final_action_return( F action ) gsl_noexcept
         : action_( std::move( action ) )
         , exception_count_( std11::uncaught_exceptions() )
+#if ! gsl_CPP17_OR_GREATER
+        , invoke_( true )
+#endif
     {
     }
 
@@ -2201,7 +2207,7 @@ private:
     F action_;
     unsigned char exception_count_;
 #if ! gsl_CPP17_OR_GREATER
-    bool invoke_ = true;
+    bool invoke_;
 #endif
 };
 template< class F >
@@ -2211,6 +2217,9 @@ public:
     explicit final_action_error( F action ) gsl_noexcept
         : action_( std::move( action ) )
         , exception_count_( std11::uncaught_exceptions() )
+#if ! gsl_CPP17_OR_GREATER
+        , invoke_( true )
+#endif
     {
     }
 
@@ -2248,7 +2257,7 @@ private:
     F action_;
     unsigned char exception_count_;
 #if ! gsl_CPP17_OR_GREATER
-    bool invoke_ = true;
+    bool invoke_;
 #endif
 };
 #else // gsl_CONFIG_DEFAULTS_VERSION < 1

--- a/test/util.t.cpp
+++ b/test/util.t.cpp
@@ -84,6 +84,7 @@ CASE( "finally: Allows to run function (pointer) on leaving scope" )
 #endif
 }
 
+#if gsl_CONFIG_DEFAULTS_VERSION < 1
 CASE( "finally: Allows to move final_action" )
 {
 #if gsl_STDLIB_CPP11_OR_GREATER_WRT_FINAL
@@ -151,6 +152,7 @@ CASE( "finally: Allows moving final_action to throw" "[.]")
 # endif
 #endif // gsl_HAVE( EXCEPTIONS )
 }
+#endif // gsl_CONFIG_DEFAULTS_VERSION < 1
 
 CASE( "on_return: Allows to perform action on leaving scope without exception (gsl_FEATURE_EXPERIMENTAL_RETURN_GUARD)" )
 {


### PR DESCRIPTION
For modern (≥v1) defaults, avoid the polymorphic hierarchy beween the state classes. Do not touch the hierarchy for v0 defaults so as not to break binary compatibility.

For C++17 and greater, we no longer have to support movability thanks to guaranteed copy elision.

Closes #178, as this ticks the last box in the checklist.