### PR TITLE
Improve hashing for `gsl::byte`

### DIFF
--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -5368,7 +5368,7 @@ template< class T >
 struct hash< ::gsl::not_null< T > > : public ::gsl::detail::conditionally_enabled_hash<is_default_constructible<hash<T>>::value>
 {
 public:
-    gsl_NODISCARD gsl_constexpr std::size_t
+    gsl_NODISCARD std::size_t
     operator()( ::gsl::not_null<T> const & v ) const
     // hash function is not `noexcept` because `as_nullable()` has preconditions
     {
@@ -5379,7 +5379,7 @@ template< class T >
 struct hash< ::gsl::not_null< T* > >
 {
 public:
-    gsl_NODISCARD gsl_constexpr std::size_t
+    gsl_NODISCARD std::size_t
     operator()( ::gsl::not_null< T* > const & v ) const gsl_noexcept
     {
         return hash<T*>()( ::gsl::as_nullable( v ) );
@@ -5390,9 +5390,15 @@ template<>
 struct hash< ::gsl::byte >
 {
 public:
-    gsl_NODISCARD gsl_constexpr std::size_t operator()( ::gsl::byte v ) const gsl_noexcept
+    gsl_NODISCARD std::size_t operator()( ::gsl::byte v ) const gsl_noexcept
     {
+#if gsl_CONFIG_DEFAULTS_VERSION >= 1
+        typedef typename std::underlying_type<::gsl::byte>::type byte_t;
+        return std::hash<byte_t>{ }( static_cast<byte_t>( v ) );
+#else // gsl_CONFIG_DEFAULTS_VERSION < 1
+            // Keep the old hashing algorithm if legacy defaults are used.
         return ::gsl::to_integer<std::size_t>( v );
+#endif // gsl_CONFIG_DEFAULTS_VERSION >= 1
     }
 };
 


### PR DESCRIPTION
Also, don't use `constexpr` in `hash<>` specializations.

Closes #63.