### PR TITLE
Support `not_null<>` for `unique_ptr<void, D>` and `shared_ptr<void>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,8 @@ not_null<>: Able to correctly deduce element_type of user-defined smart pointers
 not_null<>: Able to deduce element_type of user-defined smart pointers even if they do not have an element_type typedef
 not_null<>: Able to deduce element_type of user-defined smart pointers even if they do not have an element_type typedef, and element_type differs from T
 not_null<>: Can handle void*
+not_null<>: Can handle unique_ptr<void, DeleterT>
+not_null<>: Can handle shared_ptr<void>
 not_null<>: Hashes match the hashes of the wrapped pointer
 not_null<>: Hash functor disabled for non-hashable pointers and enabled for hashable pointers
 owner<>: Disallows construction from a non-pointer type (define gsl_CONFIG_CONFIRMS_COMPILATION_ERRORS)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,8 +82,8 @@ jobs:
       # Make Valgrind return a non-zero exit code when errors occur in order to make the job fail.
       # Also, enforce DWARF version 4 because Valgrind cannot read DWARF version 5 yet (cf. https://bugs.kde.org/show_bug.cgi?id=452758).
       cmakeConfigArgs: '-DGSL_LITE_OPT_BUILD_TESTS=ON -DCMAKE_CXX_FLAGS="-gdwarf-4" -DMEMORYCHECK_COMMAND_OPTIONS="--error-exitcode=1 --leak-check=full"'
-      cmakeBuildArgs: '<cmakeBuildArgs> --target gsl-lite-v1-cpp20.t'
-      cmakeTestArgs: '<cmakeTestArgs> --test-action memcheck --tests-regex gsl-lite-v1-cpp20'
+      cmakeBuildArgs: '<cmakeBuildArgs> --target gsl-lite-v0-cpp20.t gsl-lite-v1-cpp20.t'
+      cmakeTestArgs: '<cmakeTestArgs> --test-action memcheck --tests-regex gsl-lite-v[0-1]-cpp20'
 
     - os: Windows
       cxxCompiler: MSVC
@@ -139,8 +139,8 @@ jobs:
       platforms: [x64]
       tag: 'sanitize'
       cmakeConfigArgs: '-DGSL_LITE_OPT_BUILD_TESTS=ON'
-      cmakeBuildArgs: '<cmakeBuildArgs> --target gsl-lite-v1-cpp17.t'
-      cmakeTestArgs: '<cmakeTestArgs> --tests-regex gsl-lite-v1-cpp17'
+      cmakeBuildArgs: '<cmakeBuildArgs> --target gsl-lite-v0-cpp17.t gsl-lite-v1-cpp17.t'
+      cmakeTestArgs: '<cmakeTestArgs> --tests-regex gsl-lite-v[0-1]-cpp17'
 
     # Clang 3.5, 3.6, 3.7, 3.8, and 3.9, 4, and 5 are tested with Travis
     #- os: Linux
@@ -161,8 +161,8 @@ jobs:
       platforms: [x64]
       tag: 'sanitize'
       cmakeConfigArgs: '-DGSL_LITE_OPT_BUILD_TESTS=ON'
-      cmakeBuildArgs: '<cmakeBuildArgs> --target gsl-lite-v1-cpp17.t'
-      cmakeTestArgs: '<cmakeTestArgs> --tests-regex gsl-lite-v1-cpp17'
+      cmakeBuildArgs: '<cmakeBuildArgs> --target gsl-lite-v0-cpp17.t gsl-lite-v1-cpp17.t'
+      cmakeTestArgs: '<cmakeTestArgs> --tests-regex gsl-lite-v[0-1]-cpp17'
 
     - os: Linux
       cxxCompiler: Clang

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -2836,8 +2836,7 @@ struct not_null_deref< Derived, T, true >
 template< class T > struct is_void : std11::false_type { };
 template< > struct is_void< void > : std11::true_type { };
 
-template< class T > struct is_void_ptr : std11::false_type { };
-template< class T > struct is_void_ptr< T* > : is_void< typename std11::remove_cv<T>::type > { };
+template< class T > struct is_void_ptr : is_void< typename detail::element_type_helper< T >::type > { };
 
 } // namespace detail
 

--- a/test/not_null.t.cpp
+++ b/test/not_null.t.cpp
@@ -1651,29 +1651,41 @@ CASE( "not_null<>: Can handle unique_ptr<void, DeleterT>" )
 #if gsl_CPP11_OR_GREATER
     std::unique_ptr< void, void ( * )( void const * ) > vp( new int( 42 ), int_const_deleter );
     void * p = vp.get();
+    ( void ) p;
 
         // Direct construction
     gsl::not_null< std::unique_ptr< void, void ( * )( void const * ) > > nvp( std::move( vp ) );
+# if gsl_CONFIG( TRANSPARENT_NOT_NULL )
     EXPECT( nvp.get() == p );
+# endif // gsl_CONFIG( TRANSPARENT_NOT_NULL )
     vp = std::move( nvp );
 
         // Indirect construction
     nvp = gsl::make_not_null( std::move( vp ) );
+# if gsl_CONFIG( TRANSPARENT_NOT_NULL )
     EXPECT( nvp.get() == p );
+# endif // gsl_CONFIG( TRANSPARENT_NOT_NULL )
 
         // Implicit conversion from `not_null<>` with typed pointer argument
     std::unique_ptr< int, void ( * )( void const * ) > tp2( new int( 42 ), int_const_deleter );
     int * pi2 = tp2.get();
+    ( void ) pi2;
     gsl::not_null< std::unique_ptr< int, void ( * )( void const * ) > > ntp2( std::move( tp2 ) );
+# if gsl_CONFIG( TRANSPARENT_NOT_NULL )
     EXPECT( ntp2.get() == pi2 );
+# endif // gsl_CONFIG( TRANSPARENT_NOT_NULL )
     gsl::not_null< std::unique_ptr< void, void ( * )( void const * ) > > nvp2( std::move( ntp2 ) );
+# if gsl_CONFIG( TRANSPARENT_NOT_NULL )
     EXPECT( nvp2.get() == pi2 );
+# endif // gsl_CONFIG( TRANSPARENT_NOT_NULL )
 
         // Implicit conversion from typed pointer
     std::unique_ptr< int, void ( * )( void const * ) > tp3( new int( 42 ), int_const_deleter );
     int * pi3 = tp3.get();
     gsl::not_null< std::unique_ptr< void, void ( * )( void const * ) > > nvp3( std::move( tp3 ) );
+# if gsl_CONFIG( TRANSPARENT_NOT_NULL )
     EXPECT( nvp3.get() == pi3 );
+# endif // gsl_CONFIG( TRANSPARENT_NOT_NULL )
 
         // Extract underlying value
     std::unique_ptr< void, void ( * )( void const * ) > vp3 = gsl::as_nullable( std::move( nvp3 ) );
@@ -1688,27 +1700,38 @@ CASE( "not_null<>: Can handle shared_ptr<void>" )
 #if gsl_CPP11_OR_GREATER
     std::shared_ptr< void > vp = std::make_shared<int>( 42 );
     void * p = vp.get();
+    ( void ) p;
 
         // Direct construction
     gsl::not_null< std::shared_ptr< void > > nvp( vp );
+# if gsl_CONFIG( TRANSPARENT_NOT_NULL )
     EXPECT( nvp.get() == p );
+# endif // gsl_CONFIG( TRANSPARENT_NOT_NULL )
     vp = std::move( nvp );
 
         // Indirect construction
     nvp = gsl::make_not_null( vp );
+# if gsl_CONFIG( TRANSPARENT_NOT_NULL )
     EXPECT( nvp.get() == p );
+# endif // gsl_CONFIG( TRANSPARENT_NOT_NULL )
 
         // Implicit conversion from `not_null<>` with typed pointer argument
     std::shared_ptr< int > tp2 = std::make_shared<int>( 42 );
     int * pi2 = tp2.get();
     gsl::not_null< std::shared_ptr< int > > ntp2( tp2 );
+# if gsl_CONFIG( TRANSPARENT_NOT_NULL )
     EXPECT( ntp2.get() == pi2 );
+# endif // gsl_CONFIG( TRANSPARENT_NOT_NULL )
     gsl::not_null< std::shared_ptr< void > > nvp2( ntp2 );
+# if gsl_CONFIG( TRANSPARENT_NOT_NULL )
     EXPECT( nvp2.get() == pi2 );
+# endif // gsl_CONFIG( TRANSPARENT_NOT_NULL )
 
         // Implicit conversion from typed pointer
     gsl::not_null< std::shared_ptr< void > > nvp2b( tp2 );
+# if gsl_CONFIG( TRANSPARENT_NOT_NULL )
     EXPECT( nvp2b.get() == pi2 );
+# endif // gsl_CONFIG( TRANSPARENT_NOT_NULL )
 
         // Extract underlying value
     std::shared_ptr< void > vp2 = gsl::as_nullable( nvp2 );


### PR DESCRIPTION
Addresses shortcoming reported in https://github.com/gsl-lite/gsl-lite/issues/340#issuecomment-1830279289.