### PR TITLE
Do not call `std::terminate()` in CUDA device code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1215,11 +1215,11 @@ on_error: Allows to perform action on leaving scope via an exception (gsl_FEATUR
 narrow_cast<>: Allows narrowing without value loss
 narrow_cast<>: Allows narrowing with value loss
 narrow<>(): Allows narrowing without value loss
-narrow<>(): Terminates when narrowing with value loss
-narrow<>(): Terminates when narrowing with sign loss
+narrow<>(): Throws when narrowing with value loss
+narrow<>(): Throws when narrowing with sign loss
 narrow_failfast<>(): Allows narrowing without value loss
-narrow_failfast<>(): Terminates when narrowing with value loss
-narrow_failfast<>(): Terminates when narrowing with sign loss
+narrow_failfast<>(): Fails when narrowing with value loss
+narrow_failfast<>(): Fails when narrowing with sign loss
 CUDA: Precondition/postcondition checks and assertions can be used in kernel code
 CUDA: span<> can be passed to kernel code
 CUDA: span<> can be used in kernel code

--- a/README.md
+++ b/README.md
@@ -706,7 +706,7 @@ Compiler             | OS              | Platforms | Versions          | CI |
 GCC                  | Linux           | x64       | 4.7 and newer     | [7, 8, 9, 10, 11, 12, 13](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
 GCC (MinGW)          | Windows         | x86, x64  | 4.8.4 and newer   |    |
 GCC (DJGPP)          | DOSBox, FreeDOS | x86       | 7.2               |    |
-GCC                  | MacOS           | x64       | 6 and newer       | [10, 11, 12, 13, 14](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
+GCC                  | MacOS           | x64       | 6 and newer       | [11, 12, 13, 14](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
 Clang                | Linux           | x64       | 3.5 and newer     | [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
 Clang with libstdc++ | Linux           | x64       | 11 and newer      | [19](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
 Clang                | Windows         | x64       | version shipped with VS 2019 | [latest](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |

--- a/README.md
+++ b/README.md
@@ -703,16 +703,16 @@ The table below mentions the compiler versions and platforms *gsl-lite* is repor
 
 Compiler             | OS              | Platforms | Versions          | CI |
 --------------------:|:----------------|-----------|------------------:|----|
-GCC                  | Linux           | x64       | 4.7 and newer     | [7, 8, 9, 10, 11](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
+GCC                  | Linux           | x64       | 4.7 and newer     | [7, 8, 9, 10, 11, 12, 13](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
 GCC (MinGW)          | Windows         | x86, x64  | 4.8.4 and newer   |    |
 GCC (DJGPP)          | DOSBox, FreeDOS | x86       | 7.2               |    |
-GCC                  | MacOS           | x64       | 6 and newer       | [10, 11, 12](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
-Clang                | Linux           | x64       | 3.5 and newer     | [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
-Clang with libstdc++ | Linux           | x64       | 11 and newer      | [16](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
+GCC                  | MacOS           | x64       | 6 and newer       | [10, 11, 12, 13, 14](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
+Clang                | Linux           | x64       | 3.5 and newer     | [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
+Clang with libstdc++ | Linux           | x64       | 11 and newer      | [19](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
 Clang                | Windows         | x64       | version shipped with VS 2019 | [latest](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
 MSVC (Visual Studio) | Windows         | x86, x64  | VS 2010 and newer | VS [2010, 2012, 2013, 2015, 2017](https://ci.appveyor.com/project/gsl-lite/gsl-lite), [2019, 2022](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
-AppleClang (Xcode)   | MacOS           | x64       | 7.3 and newer     | [11.0.3, 12, 12.0.5, 13, 14](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
-NVCC (CUDA Toolkit)  | Linux, Windows  | x64       | 10.2 and newer    | [11.8, 12.1](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
+AppleClang (Xcode)   | MacOS           | x64       | 7.3 and newer     | [13, 14, 15, 16](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
+NVCC (CUDA Toolkit)  | Linux, Windows  | x64       | 10.2 and newer    | [11.7, 11.8, 12.1, 12.6](https://dev.azure.com/gsl-lite/gsl-lite/_build?definitionId=1) |
 ARMCC                |                 | ARM       | 5 and newer       | |
 
 

--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ Define this macro to 1 to add the unconstrained span constructor for containers 
 Note: an alternative is to use the constructor tagged `with_container`: `span<V> s(gsl::with_container, cont)`.
 
 #### `gsl_CONFIG_NARROW_THROWS_ON_TRUNCATION=0`
-Define this macro to 1 to have `narrow<>()` always throw a `narrowing_error` exception if the narrowing conversion loses information due to truncation. If `gsl_CONFIG_NARROW_THROWS_ON_TRUNCATION` is 0 and `gsl_CONFIG_CONTRACT_VIOLATION_THROWS` is not defined, `narrow<>()` instead calls `std::terminate()` on information loss. **Default is 0.**
+Define this macro to 1 to have `narrow<>()` always throw a `narrowing_error` exception if the narrowing conversion loses information due to truncation. If `gsl_CONFIG_NARROW_THROWS_ON_TRUNCATION` is 0 and `gsl_CONFIG_CONTRACT_VIOLATION_THROWS` is not defined, `narrow<>()` instead terminates on information loss (using `std::terminate()` if available and a trap instruction otherwise, e.g. for CUDA device code). **Default is 0.**
 
 #### `gsl_CONFIG_CONFIRMS_COMPILATION_ERRORS=0`
 Define this macro to 1 to experience the by-design compile-time errors of the GSL components in the test suite. **Default is 0.**

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
 
     - os: Linux
       cxxCompiler: GCC
-      cxxCompilerVersions: [12]
+      cxxCompilerVersions: [13]
       cmakeBuildConfigurations: [Debug, RelWithDebInfo]
       platforms: [x64]
       tag: 'memcheck'
@@ -49,10 +49,10 @@ jobs:
 
     - os: Linux
       cxxCompiler: GCC
-      cxxCompilerVersions: [12]
+      cxxCompilerVersions: [13]
       cmakeBuildConfigurations: [Debug, RelWithDebInfo]
       cudaCompiler: NVCC
-      cudaCompilerVersions: [12_1]
+      cudaCompilerVersions: [12_6]
       platforms: [x64]
       cmakeConfigArgs: '-DGSL_LITE_OPT_BUILD_CUDA_TESTS=ON'
 
@@ -68,7 +68,7 @@ jobs:
 
     - os: Linux
       cxxCompiler: Clang
-      cxxCompilerVersions: [16]
+      cxxCompilerVersions: [19]
       cmakeBuildConfigurations: [Debug, RelWithDebInfo]
       platforms: [x64]
       tag: 'memcheck'
@@ -107,14 +107,14 @@ jobs:
       cxxCompiler: MSVC
       cxxCompilerVersions: [VS2022]
       cudaCompiler: NVCC
-      cudaCompilerVersions: [11_8]
+      cudaCompilerVersions: [12_6]
       cmakeBuildConfigurations: [Debug, RelWithDebInfo]
       platforms: [x64]
       cmakeConfigArgs: '-DGSL_LITE_OPT_BUILD_CUDA_TESTS=ON'
 
     - os: MacOS
       cxxCompiler: AppleClang
-      cxxCompilerVersions: [14]
+      cxxCompilerVersions: [16]
       cmakeBuildConfigurations: [Debug, RelWithDebInfo]
       platforms: [x64]
       cmakeBuildArgs: '<cmakeBuildArgs> --target gsl-lite-v1-cpp17.t'
@@ -133,7 +133,7 @@ jobs:
 
     - os: Linux
       cxxCompiler: GCC
-      cxxCompilerVersions: [12]
+      cxxCompilerVersions: [13]
       cxxStandardLibraryDebugMode: true
       cxxSanitizers: [AddressSanitizer, UndefinedBehaviorSanitizer]
       platforms: [x64]
@@ -150,12 +150,12 @@ jobs:
 
     - os: Linux
       cxxCompiler: Clang
-      cxxCompilerVersions: [6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+      cxxCompilerVersions: [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
       platforms: [x64]
 
     - os: Linux
       cxxCompiler: Clang
-      cxxCompilerVersions: [16]
+      cxxCompilerVersions: [19]
       cxxStandardLibraryDebugMode: true
       cxxSanitizers: [AddressSanitizer, UndefinedBehaviorSanitizer, ImplicitIntegerArithmeticValueChange]
       platforms: [x64]
@@ -166,7 +166,7 @@ jobs:
 
     - os: Linux
       cxxCompiler: Clang
-      cxxCompilerVersions: [16]
+      cxxCompilerVersions: [19]
       cxxStandardLibrary: libstdc++
       platforms: [x64]
       tag: 'libstdc++'
@@ -196,10 +196,10 @@ jobs:
 
     - os: MacOS
       cxxCompiler: GCC
-      cxxCompilerVersions: [10, 11, 12]
+      cxxCompilerVersions: [10, 11, 12, 13, 14]
       platforms: [x64]
 
     - os: MacOS
       cxxCompiler: AppleClang
-      cxxCompilerVersions: [11_0_3, 12, 12_0_5, 13, 13_1_6, 14]
+      cxxCompilerVersions: [13, 14, 15, 16]
       platforms: [x64]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -196,7 +196,7 @@ jobs:
 
     - os: MacOS
       cxxCompiler: GCC
-      cxxCompilerVersions: [10, 11, 12, 13, 14]
+      cxxCompilerVersions: [11, 12, 13, 14]
       platforms: [x64]
 
     - os: MacOS

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -2529,13 +2529,13 @@ namespace detail {
 
 template< class T, class U >
 gsl_NODISCARD gsl_constexpr14
-#if !gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION ) && !defined( gsl_CONFIG_CONTRACT_VIOLATION_THROWS )
+#if ! gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION )
 gsl_api
-#endif
+#endif // ! gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION )
 inline T
 narrow( U u )
 {
-#if gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION ) && ! gsl_HAVE( EXCEPTIONS )
+#if ! gsl_HAVE( EXCEPTIONS ) && gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION )
     gsl_STATIC_ASSERT_( detail::dependent_false< T >::value,
         "According to the GSL specification, narrow<>() throws an exception of type narrowing_error on truncation. Therefore "
         "it cannot be used if exceptions are disabled. Consider using narrow_failfast<>() instead which raises a precondition "
@@ -2544,21 +2544,14 @@ narrow( U u )
 
     T t = static_cast<T>( u );
 
-    if ( static_cast<U>( t ) != u )
-    {
-#if gsl_HAVE( EXCEPTIONS ) && ( gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION ) || defined( gsl_CONFIG_CONTRACT_VIOLATION_THROWS ) )
-        throw narrowing_error();
-#else
-        std::terminate();
-#endif
-    }
-
 #if gsl_HAVE( TYPE_TRAITS )
 # if gsl_COMPILER_NVCC_VERSION || gsl_COMPILER_NVHPC_VERSION
-    if ( ! detail::have_same_sign( t, u, detail::is_same_signedness<T, U>() ) )
+    if ( static_cast<U>( t ) != u
+        || ! detail::have_same_sign( t, u, detail::is_same_signedness<T, U>() ) )
 # else
     gsl_SUPPRESS_MSVC_WARNING( 4127, "conditional expression is constant" )
-    if ( ! detail::is_same_signedness<T, U>::value && ( t < T() ) != ( u < U() ) )
+    if ( static_cast<U>( t ) != u
+        || ! detail::is_same_signedness<T, U>::value && ( t < T() ) != ( u < U() ) )
 # endif
 #else
     // Don't assume T() works:
@@ -2567,7 +2560,8 @@ narrow( U u )
     // Suppress: pointless comparison of unsigned integer with zero.
 #  pragma diag_suppress 186
 # endif
-    if ( ( t < 0 ) != ( u < 0 ) )
+    if ( static_cast<U>( t ) != u
+        || ( t < 0 ) != ( u < 0 ) )
 # if gsl_COMPILER_NVHPC_VERSION
     // Restore: pointless comparison of unsigned integer with zero.
 #  pragma diag_default 186
@@ -2575,11 +2569,15 @@ narrow( U u )
 
 #endif
     {
-#if gsl_HAVE( EXCEPTIONS ) && ( gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION ) || defined( gsl_CONFIG_CONTRACT_VIOLATION_THROWS ) )
+#if gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION )
         throw narrowing_error();
-#else
+#else // ! gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION )
+# if gsl_DEVICE_CODE
+        gsl_TRAP_();
+# else // host code
         std::terminate();
-#endif
+# endif
+#endif // gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION )
     }
 
     return t;
@@ -2591,14 +2589,14 @@ narrow_failfast( U u )
 {
     T t = static_cast<T>( u );
 
-    gsl_Expects( static_cast<U>( t ) == u );
+    gsl_Assert( static_cast<U>( t ) == u );
 
 #if gsl_HAVE( TYPE_TRAITS )
 # if gsl_COMPILER_NVCC_VERSION || gsl_COMPILER_NVHPC_VERSION
-    gsl_Expects( ::gsl::detail::have_same_sign( t, u, ::gsl::detail::is_same_signedness<T, U>() ) );
+    gsl_Assert( ::gsl::detail::have_same_sign( t, u, ::gsl::detail::is_same_signedness<T, U>() ) );
 # else
     gsl_SUPPRESS_MSVC_WARNING( 4127, "conditional expression is constant" )
-    gsl_Expects( ( ::gsl::detail::is_same_signedness<T, U>::value || ( t < T() ) == ( u < U() ) ) );
+    gsl_Assert( ( ::gsl::detail::is_same_signedness<T, U>::value || ( t < T() ) == ( u < U() ) ) );
 # endif
 #else
     // Don't assume T() works:
@@ -2607,7 +2605,7 @@ narrow_failfast( U u )
     // Suppress: pointless comparison of unsigned integer with zero.
 #  pragma diag_suppress 186
 # endif
-    gsl_Expects( ( t < 0 ) == ( u < 0 ) );
+    gsl_Assert( ( t < 0 ) == ( u < 0 ) );
 # if gsl_COMPILER_NVHPC_VERSION
     // Restore: pointless comparison of unsigned integer with zero.
 #  pragma diag_default 186

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -575,6 +575,10 @@
 // AppleClang 13.1.6  __apple_build_version__ == 13160021  gsl_COMPILER_APPLECLANG_VERSION == 1316  (Xcode 13.3–13.4.1)              (LLVM 13.0.0)
 // AppleClang 14.0.0  __apple_build_version__ == 14000029  gsl_COMPILER_APPLECLANG_VERSION == 1400  (Xcode 14.0–14.2)                (LLVM 14.0.0)
 // AppleClang 14.0.3  __apple_build_version__ == 14030022  gsl_COMPILER_APPLECLANG_VERSION == 1403  (Xcode 14.3)                     (LLVM 15.0.0)
+// AppleClang 15.0.0  __apple_build_version__ == 15000040  gsl_COMPILER_APPLECLANG_VERSION == 1500  (Xcode 15.0)                     (LLVM 16.0.0)
+// AppleClang 15.0.0  __apple_build_version__ == 15000100  gsl_COMPILER_APPLECLANG_VERSION == 1500  (Xcode 15.1–15.2)                (LLVM 16.0.0)
+// AppleClang 15.0.0  __apple_build_version__ == 15000309  gsl_COMPILER_APPLECLANG_VERSION == 1500  (Xcode 15.3–15.4)                (LLVM 16.0.0)
+// AppleClang 16.0.0  __apple_build_version__ == 16000026  gsl_COMPILER_APPLECLANG_VERSION == 1600  (Xcode 16.0)                     (LLVM 17.0.6)
 
 #if defined( __apple_build_version__ )
 # define gsl_COMPILER_APPLECLANG_VERSION  gsl_COMPILER_VERSION( __clang_major__, __clang_minor__, __clang_patchlevel__ )

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -2551,7 +2551,7 @@ narrow( U u )
 # else
     gsl_SUPPRESS_MSVC_WARNING( 4127, "conditional expression is constant" )
     if ( static_cast<U>( t ) != u
-        || ! detail::is_same_signedness<T, U>::value && ( t < T() ) != ( u < U() ) )
+        || ( ! detail::is_same_signedness<T, U>::value && ( t < T() ) != ( u < U() ) ) )
 # endif
 #else
     // Don't assume T() works:

--- a/test/util.t.cpp
+++ b/test/util.t.cpp
@@ -266,9 +266,9 @@ CASE( "narrow<>(): Allows narrowing without value loss" )
 #endif // gsl_HAVE( EXCEPTIONS )
 }
 
-CASE( "narrow<>(): Terminates when narrowing with value loss" )
+CASE( "narrow<>(): Throws when narrowing with value loss" )
 {
-#if gsl_HAVE( EXCEPTIONS )
+#if gsl_HAVE( EXCEPTIONS ) && gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION )
     EXPECT_THROWS_AS( (void) narrow<char>( 300 ), narrowing_error );
 
 # if gsl_STDLIB_CPP11_OR_GREATER
@@ -285,12 +285,12 @@ CASE( "narrow<>(): Terminates when narrowing with value loss" )
     EXPECT_THROWS_AS( (void) narrow<  std::int8_t>( std::uint16_t( u8 ) ), narrowing_error );
     EXPECT_THROWS_AS( (void) narrow<  std::int8_t>( std::uint16_t(u16 ) ), narrowing_error );
 # endif // gsl_STDLIB_CPP11_OR_GREATER
-#endif // gsl_HAVE( EXCEPTIONS )
+#endif // gsl_HAVE( EXCEPTIONS ) && gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION )
 }
 
-CASE( "narrow<>(): Terminates when narrowing with sign loss" )
+CASE( "narrow<>(): Throws when narrowing with sign loss" )
 {
-#if gsl_HAVE( EXCEPTIONS )
+#if gsl_HAVE( EXCEPTIONS ) && gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION )
     EXPECT_THROWS_AS( (void) narrow<unsigned>( -42 ), narrowing_error );
 
 # if gsl_STDLIB_CPP11_OR_GREATER
@@ -300,7 +300,7 @@ CASE( "narrow<>(): Terminates when narrowing with sign loss" )
     EXPECT_THROWS_AS( (void) narrow< std::uint8_t>(  std::int16_t( i8n) ), narrowing_error );
     EXPECT_THROWS_AS( (void) narrow< std::uint8_t>(  std::int16_t(i16n) ), narrowing_error );
 # endif // gsl_STDLIB_CPP11_OR_GREATER
-#endif // gsl_HAVE( EXCEPTIONS )
+#endif // gsl_HAVE( EXCEPTIONS ) && gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION )
 }
 
 CASE( "narrow_failfast<>(): Allows narrowing without value loss" )
@@ -336,7 +336,7 @@ CASE( "narrow_failfast<>(): Allows narrowing without value loss" )
 #endif // gsl_STDLIB_CPP11_OR_GREATER
 }
 
-CASE( "narrow_failfast<>(): Terminates when narrowing with value loss" )
+CASE( "narrow_failfast<>(): Fails when narrowing with value loss" )
 {
     EXPECT_THROWS_AS( (void) narrow_failfast<char>( 300 ), fail_fast );
 
@@ -356,7 +356,7 @@ CASE( "narrow_failfast<>(): Terminates when narrowing with value loss" )
 #endif // gsl_STDLIB_CPP11_OR_GREATER
 }
 
-CASE( "narrow_failfast<>(): Terminates when narrowing with sign loss" )
+CASE( "narrow_failfast<>(): Fails when narrowing with sign loss" )
 {
     EXPECT_THROWS_AS( (void) narrow_failfast<unsigned>( -42 ), fail_fast );
 


### PR DESCRIPTION
Previously, calling `narrow<>()` from CUDA device code should have resulted
in a compile error but but did not due to a weird bug in NVCC pertaining to
the experimental "--expt-relaxed-constexpr" flag (cf. https://github.com/rapidsai/cudf/issues/7795).

This commit makes two changes to mitigate this problem:

(1) `narrow<>()` no longer responds to `gsl_CONFIG_CONTRACT_VIOLATION_THROWS`
    because it does not do contract checking. Therefore, it plainly fails to
    compile for `gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION )` if exceptions are
    unavailable (e.g. in device code).

(2) For `!gsl_CONFIG( NARROW_THROWS_ON_TRUNCATION )`, `narrow<>()` now makes
    sure that the program is terminated by issuing a trap instruction if
    `std::terminate()` is not available.

Also, `narrow_failfast<>()` now uses `gsl_Assert()` rather than `gsl_Expects()`.